### PR TITLE
feat: Add additional linter checks and a Makefile to run locally.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+### Golang files (with tooling) ###
+.bin/
+
+### Local development ###
+# Local build system configuration
+/local.mk
+

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,12 +25,15 @@ linters-settings:
       - style
   gocyclo:
     min-complexity: 15
+  gofumpt:
+    module-path: github.com/snyk/cli-extension-os-flows
+    extra-rules: true
   goimports:
-    local-prefixes: github.com/snyk/cli-extension-sbom
+    local-prefixes: github.com/snyk/cli-extension-os-flows
   gosimple:
     checks: ["all"]
   govet:
-    check-shadowing: true
+    enable-all: true
     disable:
       - fieldalignment
   ireturn:
@@ -51,6 +54,34 @@ linters-settings:
     for-loops: true
   promlinter:
     strict: true
+  revive:
+    rules:
+      - name: blank-imports
+        disabled: true
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+        disabled: true
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
   staticcheck:
     checks: ["all"]
   stylecheck:
@@ -60,6 +91,10 @@ linters-settings:
     http-status-code-whitelist: []
   varcheck:
     exported-fields: true
+  wrapcheck:
+    ignoreSigs:
+      - .EntryPointLegacy(
+      - .Errorf(
 
 linters:
   enable:
@@ -82,6 +117,7 @@ linters:
     - gocritic
     - gocyclo
     - godot
+    - gofumpt
     - goimports
     - goprintffuncname
     - gosec
@@ -98,6 +134,7 @@ linters:
     - prealloc
     - predeclared
     - promlinter
+    - revive
     - rowserrcheck
     - sqlclosecheck
     - stylecheck
@@ -111,14 +148,19 @@ linters:
     - usestdlibvars
     - wastedassign
     - whitespace
+    - wrapcheck
 
 issues:
   exclude-rules:
     - path: _test\.go
       linters:
         - bodyclose
+        - forcetypeassert
         - goconst
         - ireturn
     - path: internal/view/(.+)_test\.go
       linters:
         - testpackage
+  include:
+    - EXC0012
+    - EXC0014

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+## Include per-checkout configuration
+#
+# local.mk is a way to override settings on a per-checkout basis.  It is in the
+# .gitignore and shouldn't be committed to git.
+-include local.mk
+
+# Project-specific overrides can go here.  Make sure to use ?= for assignment,
+# though; otherwise you may overwrite a value from local.mk.  Using ?= in a
+# Makefile means that the variable should only be set if it is not already set.
+#
+######################################################
+### BEGIN PROJECT-SPECIFIC CONFIGURATION OVERRIDES ###
+######################################################
+
+# Define GOCI_LINT_V for golangci-lint. The install.sh script handles OS/ARCH.
+# User requested v1.64.6 for local macOS use.
+GOCI_LINT_V?=v1.64.6
+
+####################################################
+### END PROJECT-SPECIFIC CONFIGURATION OVERRIDES ###
+####################################################
+
+# Variables
+GO_BIN?=$(shell pwd)/.bin
+OS?=$(shell go env GOOS)
+
+# Update PATH for make targets
+SHELL:=env PATH=$(GO_BIN):$(PATH) $(SHELL)
+
+.PHONY: all
+all: install-tools lint-go ## Install tools and run linters
+
+.PHONY: install-tools
+install-tools: ## Install golangci-lint for local development
+	mkdir -p ${GO_BIN}
+ifndef CI
+	@echo "Installing golangci-lint ${GOCI_LINT_V} to ${GO_BIN}..."
+	curl -sSfL 'https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh' | sh -s -- -b ${GO_BIN} ${GOCI_LINT_V}
+	@echo "golangci-lint installed."
+else
+	@echo "CI environment detected, skipping local installation of golangci-lint."
+endif
+
+.PHONY: lint
+lint: lint-go ## Run all linters (currently only golangci-lint)
+
+.PHONY: lint-go
+lint-go: ## Run golangci linters
+ifdef CI
+	mkdir -p test/results
+	golangci-lint run --out-format junit-xml ./... > test/results/lint-tests.xml
+else
+	golangci-lint run -v ./...
+endif
+
+.PHONY: clean
+clean: ## Clean up the .bin directory
+	@echo "Cleaning up .bin directory..."
+	rm -rf $(GO_BIN)
+
+help: ## Show this help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/internal/commands/ostest/ostest.go
+++ b/internal/commands/ostest/ostest.go
@@ -11,10 +11,11 @@ package ostest
 import (
 	"fmt"
 
-	"github.com/snyk/cli-extension-os-flows/internal/errors"
-	"github.com/snyk/cli-extension-os-flows/internal/flags"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/code_workflow"
 	"github.com/snyk/go-application-framework/pkg/workflow"
+
+	"github.com/snyk/cli-extension-os-flows/internal/errors"
+	"github.com/snyk/cli-extension-os-flows/internal/flags"
 )
 
 // WorkflowID is the identifier for the Open Source Test workflow.

--- a/pkg/osflows/osflows.go
+++ b/pkg/osflows/osflows.go
@@ -12,8 +12,9 @@ package osflows
 import (
 	"fmt"
 
-	"github.com/snyk/cli-extension-os-flows/internal/commands/ostest"
 	"github.com/snyk/go-application-framework/pkg/workflow"
+
+	"github.com/snyk/cli-extension-os-flows/internal/commands/ostest"
 )
 
 // Init registers the "test" workflow.


### PR DESCRIPTION
### What This Provides:

- Updates linter config with additional checks such as enforced Godoc styling.
- a Makefile to lint locally using the same linter version as on CircleCI.

### How to Use:
- run "make install-tools" to install golangci-lint 1.64.6 into .bin. This version matches what .circleci/config.yml runs through a Docker image.
- run "make lint" for local linting.