### PR TITLE
fix: call legacy flow in a more straightforward way; use GetWorkflow response appropriately.

### DIFF
--- a/internal/commands/ostest/ostest.go
+++ b/internal/commands/ostest/ostest.go
@@ -28,7 +28,7 @@ const FeatureFlagSBOMTestReachability = "feature_flag_sbom_test_reachability"
 // RegisterWorkflows registers the "test" workflow.
 func RegisterWorkflows(e workflow.Engine) error {
 	// Check if workflow already exists
-	if existing, _ := e.GetWorkflow(WorkflowID); existing != nil {
+	if _, ok := e.GetWorkflow(WorkflowID); ok {
 		return fmt.Errorf("workflow with ID %s already exists", WorkflowID)
 	}
 
@@ -64,11 +64,7 @@ func OSWorkflow(
 
 	if !config.GetBool(flags.FlagUnifiedTestAPI) && riskScoreThreshold == -1 && !sbomTestReachability {
 		logger.Debug().Msg("Using legacy flow since risk score threshold, unified test and sbom reachability flags are disabled")
-		data, err := code_workflow.EntryPointLegacy(icontext)
-		if err != nil {
-			return nil, fmt.Errorf("failed to run legacy code workflow: %w", err)
-		}
-		return data, nil
+		return code_workflow.EntryPointLegacy(icontext)
 	}
 
 	if sbomTestReachability && !config.GetBool(FeatureFlagSBOMTestReachability) {

--- a/internal/commands/ostest/ostest_test.go
+++ b/internal/commands/ostest/ostest_test.go
@@ -125,7 +125,7 @@ func TestOSWorkflow_FlagCombinations(t *testing.T) {
 		{
 			name:               "Unified test API flag set to true",
 			unifiedTestAPI:     true,
-			riskScoreThreshold: -1,
+			riskScoreThreshold: -1, // -1 is default == not set
 			expectedError:      "feature is not yet available",
 		},
 		{


### PR DESCRIPTION
Responses to previous PR suggestions:
  - call legacy flow in a more straightforward way (now that linter allows returning unwrapped errors).
  - also use the GetWorkflow() "ok" return as intended.