### PR TITLE
feat: build a depgraph for --file param and call test API on it

### DIFF
--- a/internal/commands/ostest/testresult.go
+++ b/internal/commands/ostest/testresult.go
@@ -1,0 +1,50 @@
+// Package ostest implements the "test" command for the Snyk CLI's Open Source security testing.
+package ostest
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
+)
+
+// processTestResult logs the details from the TestResult interface.
+//
+//nolint:forbidigo // todo: for demo purposes
+func processTestResult(status testapi.TestResult) {
+	fmt.Println("--- Test Result Details ---")
+	if status.GetTestID() != nil {
+		fmt.Printf("Test ID: %s\n", status.GetTestID().String())
+	} else {
+		fmt.Printf("Test ID: <nil>\n")
+	}
+	fmt.Printf("State:   %s\n", status.GetState())
+	if status.GetOutcome() != nil {
+		fmt.Printf("Outcome: %s\n", *status.GetOutcome())
+	} else {
+		fmt.Printf("Outcome: <nil>\n")
+	}
+	if status.GetOutcomeReason() != nil {
+		fmt.Printf("Reason:  %s\n", *status.GetOutcomeReason())
+	}
+	logJSON("Effective Summary:", status.GetEffectiveSummary())
+	fmt.Println("-------------------------")
+}
+
+// logJSON is a helper function to log JSON data with a prefix.
+//
+//nolint:forbidigo // todo: for demo purposes
+func logJSON(prefix string, v any) {
+	if v == nil {
+		fmt.Printf("%s <nil>\n", prefix)
+		return
+	}
+
+	jsonBytes, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		fmt.Printf("%s Error marshaling to JSON: %v\n", prefix, err)
+		return
+	}
+
+	fmt.Printf("%s\n%s\n", prefix, string(jsonBytes))
+}

--- a/internal/common/depgraph.go
+++ b/internal/common/depgraph.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/snyk/go-application-framework/pkg/workflow"
+
+	"github.com/snyk/cli-extension-os-flows/internal/errors"
+)
+
+// DepGraphWorkflowID is the identifier for the dependency graph workflow.
+var DepGraphWorkflowID = workflow.NewWorkflowIdentifier("depgraph")
+
+// DepGraphResult contains the results of a dependency graph generation.
+type DepGraphResult struct {
+	Name          string
+	DepGraphBytes []json.RawMessage
+}
+
+// GetDepGraph retrieves the dependency graph for the given invocation context.
+func GetDepGraph(ictx workflow.InvocationContext) (*DepGraphResult, error) {
+	engine := ictx.GetEngine()
+	config := ictx.GetConfiguration()
+	logger := ictx.GetEnhancedLogger()
+	errFactory := errors.NewErrorFactory(logger)
+
+	logger.Println("Invoking depgraph workflow")
+
+	depGraphConfig := config.Clone()
+	depGraphs, err := engine.InvokeWithConfig(DepGraphWorkflowID, depGraphConfig)
+	if err != nil {
+		return nil, errFactory.NewDepGraphWorkflowError(err)
+	}
+
+	numGraphs := len(depGraphs)
+	logger.Printf("Generating documents for %d depgraph(s)\n", numGraphs)
+	depGraphsBytes := make([]json.RawMessage, numGraphs)
+	for i, depGraph := range depGraphs {
+		depGraphBytes, err := getPayloadBytes(depGraph)
+		if err != nil {
+			return nil, errFactory.NewDepGraphWorkflowError(err)
+		}
+		depGraphsBytes[i] = depGraphBytes
+	}
+
+	return &DepGraphResult{
+		Name:          "",
+		DepGraphBytes: depGraphsBytes,
+	}, nil
+}
+
+func getPayloadBytes(data workflow.Data) ([]byte, error) {
+	payload := data.GetPayload()
+	bytes, ok := payload.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("invalid payload type (want []byte, got %T)", payload)
+	}
+	return bytes, nil
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -97,3 +97,11 @@ func (ef *ErrorFactory) NewDirectoryIsEmptyError(dirPath string) *OSFlowsExtensi
 		fmt.Sprintf("The directory %s is empty", dirPath),
 	)
 }
+
+// NewDepGraphWorkflowError creates a new error for failures in the dependency graph workflow.
+func (ef *ErrorFactory) NewDepGraphWorkflowError(err error) *OSFlowsExtensionError {
+	return ef.newErr(
+		fmt.Errorf("error while invoking depgraph workflow: %w", err),
+		"An error occurred while running the underlying analysis needed to generate the test.",
+	)
+}

--- a/internal/snykclient/snykclient.go
+++ b/internal/snykclient/snykclient.go
@@ -1,0 +1,59 @@
+// Package snykclient provides a client for interacting with the Snyk API.
+package snykclient
+
+import (
+	"net/http"
+	"time"
+)
+
+// SnykClient is a client for interacting with the Snyk API.
+type SnykClient struct {
+	client     *http.Client
+	apiBaseURL string
+	orgID      string
+}
+
+// backoffFn defines the signature for backoff functions.
+type backoffFn func()
+
+// GetClient returns the HTTP client.
+func (s *SnykClient) GetClient() *http.Client {
+	return s.client
+}
+
+// GetAPIBaseURL returns the API base URL.
+func (s *SnykClient) GetAPIBaseURL() string {
+	// TODO: remove this when we go GA.
+	return s.apiBaseURL + "/closed-beta/"
+}
+
+// GetOrgID returns the organization ID.
+func (s *SnykClient) GetOrgID() string {
+	return s.orgID
+}
+
+// DefaultBackoff is the default backoff function.
+var DefaultBackoff backoffFn = func() {
+	// TODO: fine tune backoff
+	time.Sleep(time.Millisecond * 500)
+}
+
+// NewSnykClient creates a new SnykClient instance.
+func NewSnykClient(c *http.Client, apiBaseURL, orgID string) *SnykClient {
+	return &SnykClient{
+		client:     createNonRedirectingHTTPClient(c),
+		apiBaseURL: apiBaseURL,
+		orgID:      orgID,
+	}
+}
+
+func createNonRedirectingHTTPClient(c *http.Client) *http.Client {
+	newClient := http.Client{
+		Transport: c.Transport,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	return &newClient
+}

--- a/internal/snykclient/snykclient_test.go
+++ b/internal/snykclient/snykclient_test.go
@@ -1,0 +1,16 @@
+package snykclient_test
+
+import (
+	_ "embed"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/cli-extension-os-flows/internal/snykclient"
+)
+
+func TestNewSnykClient(t *testing.T) {
+	client := snykclient.NewSnykClient(http.DefaultClient, "http://example.com", "org1")
+	assert.NotNil(t, client)
+}


### PR DESCRIPTION
# What this does:
Builds a depgraph for the --file param and call test API on it; includes risk score param [change 2 of 2]

# Summary of changes:
- [DGP-171] - supports --risk-score-threshold=<value> and --unified-test=<true|false> to force the new Test API. Otherwise test invokes legacy CLI.
- Organized so both Risk Score and Reachability call the Test API. However, risk score does so with a DepGraph and Reachability is stubbed out to do so with a Reachability struct.
- [DGP-390] - for risk score, builds a depgraph using the existing CLI dep-graph extension. Does so for a single file only, specified via --file=<filename>

TODO: build up tests with test result mocks since they mostly fail with "not implemented" now

[DGP-171]: https://snyksec.atlassian.net/browse/DGP-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DGP-390]: https://snyksec.atlassian.net/browse/DGP-390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ