### PR TITLE
feat: [DGP-525] Add severity-threshold param to OS test

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -11,6 +11,9 @@ const FlagProjectName = "project-name"
 // FlagRiskScoreThreshold is the flag for the minimum risk score for which findings are included.
 const FlagRiskScoreThreshold = "risk-score-threshold"
 
+// FlagSeverityThreshold reports only vulnerabilities at the specified level or higher.
+const FlagSeverityThreshold = "severity-threshold"
+
 // FlagUnifiedTestAPI forces use of the modern (non-legacy) workflow even without risk score threshold.
 const FlagUnifiedTestAPI = "unified-test"
 
@@ -27,11 +30,13 @@ const FlagSourceDir = "source-dir"
 func OSTestFlagSet() *pflag.FlagSet {
 	flagSet := pflag.NewFlagSet("snyk-cli-extension-os-flows", pflag.ExitOnError)
 
+	// Open Source
 	flagSet.String(FlagFile, "", "Specify a test subject file.")
 	flagSet.String(FlagProjectName, "", "Specify a name for the project.")
 
 	flagSet.Bool(FlagUnifiedTestAPI, false, "Use the unified test API workflow.")
-	flagSet.Int(FlagRiskScoreThreshold, -1, "Include findings at or over this risk score threshold")
+	flagSet.Int(FlagRiskScoreThreshold, -1, "Include findings at or over this risk score threshold.")
+	flagSet.String(FlagSeverityThreshold, "", "Report only findings at the specified level or higher.")
 
 	// Reachability
 	flagSet.Bool(FlagReachability, false, "Run reachability analysis on source code.")

--- a/internal/legacy/transform/transform.go
+++ b/internal/legacy/transform/transform.go
@@ -196,7 +196,7 @@ func ConvertSnykSchemaFindingsToLegacyJSON(params *SnykSchemaToLegacyParams) (js
 	subject := params.TestResult.GetTestSubject()
 	depGraphSubject, err := subject.AsDepGraphSubject()
 	if err != nil {
-		panic(err)
+		return nil, params.ErrFactory.NewLegacyJSONTransformerError(fmt.Errorf("marshaling to json: %w", err))
 	}
 
 	var path string


### PR DESCRIPTION
feat: [DGP-525] Adds severity threshold for the unified-test flow.  It was already supported in legacy flow.

- includes basic parameter test


[DGP-525]: https://snyksec.atlassian.net/browse/DGP-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ