### PR TITLE
chore: Bump toolchain to 1.24.1, as required by golang.org/x/mod v0.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/snyk/cli-extension-os-flows
 
 go 1.23.10
 
+toolchain go1.24.1
+
 require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
  - this is to align with the CLI CI/CD build