### PR TITLE
feat: DGP-498 - add missing legacy JSON output fields

### DIFF
--- a/internal/commands/ostest/ostest.go
+++ b/internal/commands/ostest/ostest.go
@@ -51,6 +51,9 @@ const ForceLegacyCLIEnvVar = "SNYK_FORCE_LEGACY_CLI"
 // ApplicationJSONContentType matches the content type for legacy JSON findings records.
 const ApplicationJSONContentType = "application/json"
 
+// LogFieldCount is the logger key for number of findings.
+const LogFieldCount = "count"
+
 // ErrNoSummaryData is returned when a test summary cannot be generated due to lack of data.
 var ErrNoSummaryData = std_errors.New("no summary data to create")
 
@@ -282,14 +285,14 @@ func runTest(
 	if err != nil {
 		logger.Error().Err(err).Msg("Error fetching findings")
 		if !complete && len(findingsData) > 0 {
-			logger.Warn().Int("count", len(findingsData)).Msg("Partial findings retrieved as an error occurred")
+			logger.Warn().Int(LogFieldCount, len(findingsData)).Msg("Partial findings retrieved as an error occurred")
 		}
 	} else {
 		logger.Info().Msgf("Findings count: %d\n", len(findingsData))
 
 		logger.Info().
 			Bool("complete", complete).
-			Int("count", len(findingsData)).
+			Int(LogFieldCount, len(findingsData)).
 			Msg("Findings fetched successfully")
 	}
 
@@ -300,6 +303,17 @@ func runTest(
 		return nil, fmt.Errorf("failed to get current working directory: %w", err)
 	}
 
+	var uniqueCount int32
+	summary := finalResult.GetEffectiveSummary()
+	if summary != nil {
+		if summary.Count > math.MaxInt32 {
+			uniqueCount = math.MaxInt32
+			logger.Warn().Uint32(LogFieldCount, summary.Count).Msg("Unique finding count exceeds int32 max, capping value.")
+		} else {
+			uniqueCount = int32(summary.Count)
+		}
+	}
+
 	legacyJSON, err := transform.ConvertSnykSchemaFindingsToLegacyJSON(
 		&transform.SnykSchemaToLegacyParams{
 			Findings:       findingsData,
@@ -307,8 +321,10 @@ func runTest(
 			ProjectName:    projectName,
 			PackageManager: packageManager,
 			CurrentDir:     currentDir,
+			UniqueCount:    uniqueCount,
 			DepCount:       depCount,
 			ErrFactory:     errFactory,
+			Logger:         logger,
 		})
 	if err != nil {
 		return nil, fmt.Errorf("error converting snyk schema findings to legacy json: %w", err)

--- a/internal/legacy/transform/transform.go
+++ b/internal/legacy/transform/transform.go
@@ -1,21 +1,24 @@
 package transform
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+
+	"github.com/rs/zerolog"
+	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
 
 	"github.com/snyk/cli-extension-os-flows/internal/errors"
 	"github.com/snyk/cli-extension-os-flows/internal/legacy/definitions"
 	"github.com/snyk/cli-extension-os-flows/internal/util"
-
-	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
 )
 
 const (
 	cvssVer3     = "3.1"
 	snykAssigner = "Snyk"
 
-	legacyTimeFormat = "2006-01-02T15:04:05.000000Z"
+	legacyTimeFormat      = "2006-01-02T15:04:05.000000Z"
+	logFieldDiscriminator = "discriminator"
 )
 
 // SnykSchemaToLegacyParams is a struct to encapsulate necessary values to the
@@ -26,8 +29,10 @@ type SnykSchemaToLegacyParams struct {
 	ProjectName    string
 	PackageManager string
 	CurrentDir     string
+	UniqueCount    int32
 	DepCount       int
 	ErrFactory     *errors.ErrorFactory
+	Logger         *zerolog.Logger
 }
 
 // ProcessProblemForVuln is responsible for decorating the vulnerability with information provided
@@ -35,71 +40,193 @@ type SnykSchemaToLegacyParams struct {
 func ProcessProblemForVuln(
 	vuln *definitions.Vulnerability,
 	prob *testapi.Problem,
+	logger *zerolog.Logger,
 ) error {
 	disc, err := prob.Discriminator()
 	if err != nil {
 		return fmt.Errorf("getting problem discriminator: %w", err)
 	}
+
 	switch disc {
 	case string(testapi.SnykVuln):
-		snykProblemVuln, err := prob.AsSnykVulnProblem()
-		if err != nil {
-			return fmt.Errorf("converting problem to snyk vuln problem: %w", err)
-		}
-		vuln.Id = snykProblemVuln.Id
-		vuln.CreationTime = snykProblemVuln.CreatedAt.Format(legacyTimeFormat)
-		vuln.CvssScore = util.Ptr(float32(snykProblemVuln.CvssBaseScore))
-		vuln.Version = snykProblemVuln.PackageVersion
-		vuln.DisclosureTime = util.Ptr(snykProblemVuln.DisclosedAt.Format(legacyTimeFormat))
-		vuln.PackageName = util.Ptr(snykProblemVuln.PackageName)
-
-		cvssSources := []definitions.CVSSSource{}
-		cvssDetails := []definitions.CVSSDetail{}
-		for _, cvss := range snykProblemVuln.CvssSources {
-			if cvss.CvssVersion == cvssVer3 && cvss.Assigner == snykAssigner {
-				vuln.CVSSv3 = util.Ptr(cvss.Vector)
-			}
-			cvssSource := definitions.CVSSSource{
-				Assigner:         util.Ptr(cvss.Assigner),
-				BaseScore:        util.Ptr(float32(cvss.BaseScore)),
-				CvssVersion:      util.Ptr(cvss.CvssVersion),
-				ModificationTime: util.Ptr(cvss.ModifiedAt.Format(legacyTimeFormat)),
-				Severity:         util.Ptr(string(cvss.Severity)),
-				Type:             util.Ptr(string(cvss.Type)),
-				Vector:           util.Ptr(cvss.Vector),
-			}
-			cvssSources = append(cvssSources, cvssSource)
-
-			if cvss.Assigner != snykAssigner && cvss.CvssVersion == cvssVer3 {
-				cvssDetails = append(cvssDetails, definitions.CVSSDetail{
-					Assigner:         *cvssSource.Assigner,
-					CvssV3BaseScore:  cvssSource.BaseScore,
-					CvssV3Vector:     cvssSource.Vector,
-					ModificationTime: cvssSource.ModificationTime,
-					Severity:         cvssSource.Severity,
-				})
-			}
-		}
-		vuln.CvssSources = &cvssSources
-		vuln.CvssDetails = &cvssDetails
-		vuln.ExploitDetails = &definitions.ExploitDetails{
-			Sources: snykProblemVuln.ExploitDetails.Sources,
-		}
-		if len(snykProblemVuln.ExploitDetails.MaturityLevels) > 0 {
-			for _, matLevel := range snykProblemVuln.ExploitDetails.MaturityLevels {
-				vuln.ExploitDetails.MaturityLevels = append(vuln.ExploitDetails.MaturityLevels, definitions.ExploitMaturityLevel{
-					Format: matLevel.Format,
-					Level:  matLevel.Level,
-					Type:   string(matLevel.Type),
-				})
-			}
-		}
+		return processSnykVulnProblem(vuln, prob, logger)
 	case string(testapi.Cve):
-		return AddCVEIdentifier(vuln, prob)
+		return processCveProblem(vuln, prob)
 	case string(testapi.Cwe):
-		return AddCWEIdentifier(vuln, prob)
+		return processCweProblem(vuln, prob)
+	case string(testapi.SnykLicense):
+		return processSnykLicenseProblem(vuln, prob, logger)
+	default:
+		logger.Warn().Str(logFieldDiscriminator, disc).Msg("unsupported problem type")
 	}
 	return nil
+}
+
+func processSnykVulnProblem(vuln *definitions.Vulnerability, prob *testapi.Problem, logger *zerolog.Logger) error {
+	snykProblemVuln, err := prob.AsSnykVulnProblem()
+	if err != nil {
+		return fmt.Errorf("converting problem to snyk vuln problem: %w", err)
+	}
+	setBasicVulnInfo(vuln, &snykProblemVuln)
+	setVulnReferences(vuln, snykProblemVuln.References)
+	setVulnSemver(vuln, &snykProblemVuln)
+	setEcosystem(vuln, &snykProblemVuln.Ecosystem, logger)
+	setVulnCvssInfo(vuln, &snykProblemVuln)
+	setVulnExploitDetails(vuln, &snykProblemVuln.ExploitDetails)
+	return nil
+}
+
+func setBasicVulnInfo(vuln *definitions.Vulnerability, snykProblemVuln *testapi.SnykVulnProblem) {
+	vuln.Id = snykProblemVuln.Id
+	vuln.CreationTime = snykProblemVuln.CreatedAt.Format(legacyTimeFormat)
+	vuln.Version = snykProblemVuln.PackageVersion
+	vuln.DisclosureTime = util.Ptr(snykProblemVuln.DisclosedAt.Format(legacyTimeFormat))
+	vuln.PackageName = &snykProblemVuln.PackageName
+	vuln.Malicious = &snykProblemVuln.IsMalicious
+	vuln.ModificationTime = util.Ptr(snykProblemVuln.ModifiedAt.Format(legacyTimeFormat))
+	vuln.PublicationTime = util.Ptr(snykProblemVuln.PublishedAt.Format(legacyTimeFormat))
+	vuln.SocialTrendAlert = &snykProblemVuln.IsSocialMediaTrending
+	if len(snykProblemVuln.Credits) > 0 {
+		vuln.Credit = &snykProblemVuln.Credits
+	}
+	if len(snykProblemVuln.InitiallyFixedInVersions) > 0 {
+		vuln.FixedIn = &snykProblemVuln.InitiallyFixedInVersions
+	}
+}
+
+func setVulnReferences(vuln *definitions.Vulnerability, snykReferences []testapi.SnykvulndbReferenceLinks) {
+	if len(snykReferences) == 0 {
+		return
+	}
+	refs := make([]definitions.Reference, 0, len(snykReferences))
+	for _, r := range snykReferences {
+		refs = append(refs, definitions.Reference{
+			Title: r.Title,
+			Url:   r.Url,
+		})
+	}
+	vuln.References = &refs
+}
+
+func getSemverInfo(affectedVersions, affectedHashes, affectedHashRanges *[]string) *definitions.SemVerInfo {
+	hasAffectedVersions := affectedVersions != nil && len(*affectedVersions) > 0
+	hasAffectedHashes := affectedHashes != nil && len(*affectedHashes) > 0
+	hasAffectedHashRanges := affectedHashRanges != nil && len(*affectedHashRanges) > 0
+
+	if !hasAffectedVersions && !hasAffectedHashes && !hasAffectedHashRanges {
+		return nil
+	}
+
+	semver := &definitions.SemVerInfo{
+		Vulnerable: []string{},
+	}
+	if hasAffectedVersions {
+		semver.Vulnerable = *affectedVersions
+	}
+
+	var vulnerableHashes []string
+	if hasAffectedHashes {
+		vulnerableHashes = append(vulnerableHashes, *affectedHashes...)
+	}
+	if hasAffectedHashRanges {
+		vulnerableHashes = append(vulnerableHashes, *affectedHashRanges...)
+	}
+	if len(vulnerableHashes) > 0 {
+		semver.VulnerableHashes = &vulnerableHashes
+	}
+	return semver
+}
+
+func setVulnSemver(vuln *definitions.Vulnerability, snykProblemVuln *testapi.SnykVulnProblem) {
+	vuln.Semver = getSemverInfo(snykProblemVuln.AffectedVersions, snykProblemVuln.AffectedHashes, snykProblemVuln.AffectedHashRanges)
+}
+
+func setLicenseSemver(v *definitions.Vulnerability, license *testapi.SnykLicenseProblem) {
+	v.Semver = getSemverInfo(license.AffectedVersions, license.AffectedHashes, license.AffectedHashRanges)
+}
+
+func setEcosystem(vuln *definitions.Vulnerability, ecosystem *testapi.SnykvulndbPackageEcosystem, logger *zerolog.Logger) {
+	ecoDisc, err := ecosystem.Discriminator()
+	if err != nil {
+		logger.Warn().Err(err).Msg("could not get ecosystem discriminator")
+		return
+	}
+	switch ecoDisc {
+	case string(testapi.Build):
+		if eco, err := ecosystem.AsSnykvulndbBuildPackageEcosystem(); err == nil {
+			vuln.Language = &eco.Language
+			vuln.PackageManager = &eco.PackageManager
+		} else {
+			logger.Warn().Err(err).Msg("could not convert ecosystem to SnykvulndbBuildPackageEcosystem")
+		}
+	case string(testapi.Os):
+		if eco, err := ecosystem.AsSnykvulndbOsPackageEcosystem(); err == nil {
+			vuln.PackageManager = util.Ptr(fmt.Sprintf("%s:%s", eco.Distribution, eco.Release))
+		} else {
+			logger.Warn().Err(err).Msg("could not convert ecosystem to SnykvulndbOsPackageEcosystem")
+		}
+	}
+}
+
+func setVulnCvssInfo(vuln *definitions.Vulnerability, snykProblemVuln *testapi.SnykVulnProblem) {
+	vuln.CvssScore = util.Ptr(float32(snykProblemVuln.CvssBaseScore))
+	if len(snykProblemVuln.CvssSources) == 0 {
+		return
+	}
+
+	snykCvssSources := snykProblemVuln.CvssSources
+	cvssSources := make([]definitions.CVSSSource, 0, len(snykCvssSources))
+	cvssDetails := make([]definitions.CVSSDetail, 0, len(snykCvssSources))
+	for _, cvss := range snykCvssSources {
+		if cvss.CvssVersion == cvssVer3 && cvss.Assigner == snykAssigner {
+			vuln.CVSSv3 = util.Ptr(cvss.Vector)
+		}
+		cvssSource := definitions.CVSSSource{
+			Assigner:         util.Ptr(cvss.Assigner),
+			BaseScore:        util.Ptr(float32(cvss.BaseScore)),
+			CvssVersion:      util.Ptr(cvss.CvssVersion),
+			ModificationTime: util.Ptr(cvss.ModifiedAt.Format(legacyTimeFormat)),
+			Severity:         util.Ptr(string(cvss.Severity)),
+			Type:             util.Ptr(string(cvss.Type)),
+			Vector:           util.Ptr(cvss.Vector),
+		}
+		cvssSources = append(cvssSources, cvssSource)
+
+		if cvss.Assigner != snykAssigner && cvss.CvssVersion == cvssVer3 {
+			cvssDetails = append(cvssDetails, definitions.CVSSDetail{
+				Assigner:         *cvssSource.Assigner,
+				CvssV3BaseScore:  cvssSource.BaseScore,
+				CvssV3Vector:     cvssSource.Vector,
+				ModificationTime: cvssSource.ModificationTime,
+				Severity:         cvssSource.Severity,
+			})
+		}
+	}
+	vuln.CvssSources = &cvssSources
+	vuln.CvssDetails = &cvssDetails
+}
+
+func setVulnExploitDetails(vuln *definitions.Vulnerability, snykExploitDetails *testapi.SnykvulndbExploitDetails) {
+	if len(snykExploitDetails.Sources) == 0 && len(snykExploitDetails.MaturityLevels) == 0 {
+		return
+	}
+
+	details := &definitions.ExploitDetails{
+		Sources: snykExploitDetails.Sources,
+	}
+
+	if len(snykExploitDetails.MaturityLevels) > 0 {
+		maturityLevels := make([]definitions.ExploitMaturityLevel, 0, len(snykExploitDetails.MaturityLevels))
+		for _, matLevel := range snykExploitDetails.MaturityLevels {
+			maturityLevels = append(maturityLevels, definitions.ExploitMaturityLevel{
+				Format: matLevel.Format,
+				Level:  matLevel.Level,
+				Type:   string(matLevel.Type),
+			})
+		}
+		details.MaturityLevels = maturityLevels
+	}
+	vuln.ExploitDetails = details
 }
 
 // ProcessLocationForVuln is responsible for decorating the legacy vulnerability
@@ -107,6 +234,7 @@ func ProcessProblemForVuln(
 func ProcessLocationForVuln(
 	vuln *definitions.Vulnerability,
 	loc *testapi.FindingLocation,
+	logger *zerolog.Logger,
 ) error {
 	locDisc, err := loc.Discriminator()
 	if err != nil {
@@ -114,6 +242,7 @@ func ProcessLocationForVuln(
 	}
 	switch locDisc {
 	case string(testapi.Source):
+		logger.Warn().Str(logFieldDiscriminator, locDisc).Msg("source location type not yet supported for legacy conversion")
 		_, err = loc.AsSourceLocation()
 		if err != nil {
 			return fmt.Errorf("converting location to source location: %w", err)
@@ -127,23 +256,27 @@ func ProcessLocationForVuln(
 		vuln.Version = l.Package.Version
 		vuln.Name = l.Package.Name
 	case string(testapi.OtherLocationTypeOther):
+		logger.Warn().Str(logFieldDiscriminator, locDisc).Msg("other location type not yet supported for legacy conversion")
 		_, err = loc.AsOtherLocation()
 		if err != nil {
 			return fmt.Errorf("converting location to other location: %w", err)
 		}
+	default:
+		logger.Warn().Str(logFieldDiscriminator, locDisc).Msg("unsupported location type")
 	}
 	return nil
 }
 
 // ProcessEvidenceForFinding extracts the dependency lineage for the vulnerability
 // from the evidence provided in the finding and returns an ordered list.
-func ProcessEvidenceForFinding(ev *testapi.Evidence) ([]string, error) {
+func ProcessEvidenceForFinding(ev *testapi.Evidence, logger *zerolog.Logger) ([]string, error) {
 	var dependencyPath []string
 	evDisc, err := ev.Discriminator()
 	if err != nil {
 		return nil, fmt.Errorf("getting evidence discriminator: %w", err)
 	}
-	if evDisc == string(testapi.DependencyPath) {
+	switch evDisc {
+	case string(testapi.DependencyPath):
 		depPathEvidence, err := ev.AsDependencyPathEvidence()
 		if err != nil {
 			return nil, fmt.Errorf("converting evidence to dependency path evidence: %w", err)
@@ -151,31 +284,33 @@ func ProcessEvidenceForFinding(ev *testapi.Evidence) ([]string, error) {
 		for _, dep := range depPathEvidence.Path {
 			dependencyPath = append(dependencyPath, fmt.Sprintf("%s@%s", dep.Name, dep.Version))
 		}
+	default:
+		logger.Warn().Str(logFieldDiscriminator, evDisc).Msg("unsupported evidence type")
 	}
 	return dependencyPath, nil
 }
 
 // FindingToLegacyVuln is the beginning of the workflow in converting a snyk schema finding into
 // a legacy vulnerability to provide legacy json outputs.
-func FindingToLegacyVuln(finding *testapi.FindingData) (*definitions.Vulnerability, error) {
+func FindingToLegacyVuln(finding *testapi.FindingData, logger *zerolog.Logger) (*definitions.Vulnerability, error) {
 	vuln := definitions.Vulnerability{Description: finding.Attributes.Description}
 	for _, problem := range finding.Attributes.Problems {
-		err := ProcessProblemForVuln(&vuln, &problem)
+		err := ProcessProblemForVuln(&vuln, &problem, logger)
 		if err != nil {
 			return nil, fmt.Errorf("handling problem for finding: %w", err)
 		}
 	}
 
 	for _, location := range finding.Attributes.Locations {
-		err := ProcessLocationForVuln(&vuln, &location)
+		err := ProcessLocationForVuln(&vuln, &location, logger)
 		if err != nil {
 			return nil, fmt.Errorf("processing location for finding: %w", err)
 		}
 	}
 
 	vuln.From = []string{}
-	for _, ev := range finding.Attributes.Evidence {
-		depPath, err := ProcessEvidenceForFinding(&ev)
+	for _, evidence := range finding.Attributes.Evidence {
+		depPath, err := ProcessEvidenceForFinding(&evidence, logger)
 		if err != nil {
 			return nil, fmt.Errorf("processing evidence for finding: %w", err)
 		}
@@ -209,40 +344,46 @@ func ConvertSnykSchemaFindingsToLegacyJSON(params *SnykSchemaToLegacyParams) (js
 		Path:              params.CurrentDir,
 		PackageManager:    params.PackageManager,
 		DisplayTargetFile: path,
+		UniqueCount:       params.UniqueCount,
 		DependencyCount:   int64(params.DepCount),
 		Vulnerabilities:   []definitions.Vulnerability{},
 		Ok:                len(params.Findings) == 0,
+		Filtered: definitions.Filtered{
+			Ignore: make([]definitions.Vulnerability, 0),
+			Patch:  make([]string, 0),
+		},
 	}
 
 	for _, finding := range params.Findings {
 		//nolint:govet // it's ok to shadow err
-		vuln, err := FindingToLegacyVuln(&finding)
+		vuln, err := FindingToLegacyVuln(&finding, params.Logger)
 		if err != nil {
 			return nil, params.ErrFactory.NewLegacyJSONTransformerError(fmt.Errorf("converting finding to legacy vuln: %w", err))
 		}
-		// TODO: does vuln.packageManager vary by finding or is it from root depGraph's pkgManager?
-		vuln.PackageManager = &params.PackageManager
+
+		// The package manager can be specific to the vulnerability. If it's not set,
+		// fall back to the one from the root of the dependency graph.
+		if vuln.PackageManager == nil {
+			vuln.PackageManager = &params.PackageManager
+		}
 		res.Vulnerabilities = append(res.Vulnerabilities, *vuln)
 	}
 
-	jsonBytes, err := json.MarshalIndent(res, "", "  ")
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	err = encoder.Encode(&res)
 	if err != nil {
 		return nil, params.ErrFactory.NewLegacyJSONTransformerError(fmt.Errorf("marshaling to json: %w", err))
 	}
-	return jsonBytes, nil
+	// encoder.Encode adds a newline, which we trim to match Marshal's behavior.
+	return bytes.TrimRight(buffer.Bytes(), "\n"), nil
 }
 
-// AddCVEIdentifier takes a (supposed) cve problem and extracts its identifier to
-// add to the vulnerability.
-func AddCVEIdentifier(v *definitions.Vulnerability, prob *testapi.Problem) error {
+// processCveProblem processes a CVE problem by extracting its identifier and adding it to the vulnerability.
+func processCveProblem(v *definitions.Vulnerability, prob *testapi.Problem) error {
 	ensureVulnHasIdentifiers(v)
-	disc, err := prob.Discriminator()
-	if err != nil {
-		return fmt.Errorf("getting discriminator for problem")
-	}
-	if disc != string(testapi.Cve) {
-		return fmt.Errorf("adding different kind of problem as a cve identifier")
-	}
 	cve, err := prob.AsCveProblem()
 	if err != nil {
 		return fmt.Errorf("converting problem to cve: %w", err)
@@ -251,23 +392,40 @@ func AddCVEIdentifier(v *definitions.Vulnerability, prob *testapi.Problem) error
 	return nil
 }
 
-// AddCWEIdentifier takes a (supposed) cwe problem and extracts its identifier to
-// add to the vulnerability.
-func AddCWEIdentifier(v *definitions.Vulnerability, prob *testapi.Problem) error {
+// processCweProblem processes a CWE problem by extracting its identifier and adding it to the vulnerability.
+func processCweProblem(v *definitions.Vulnerability, prob *testapi.Problem) error {
 	ensureVulnHasIdentifiers(v)
-	disc, err := prob.Discriminator()
-	if err != nil {
-		return fmt.Errorf("getting discriminator for problem")
-	}
-	if disc != string(testapi.Cwe) {
-		return fmt.Errorf("adding different kind of problem as a cwe identifier")
-	}
 	cwe, err := prob.AsCweProblem()
 	if err != nil {
 		return fmt.Errorf("converting problem to cwe: %w", err)
 	}
 	v.Identifiers.CWE = append(v.Identifiers.CWE, cwe.Id)
 	return nil
+}
+
+// processSnykLicenseProblem processes a Snyk license problem by extracting its data and populating the vulnerability.
+func processSnykLicenseProblem(v *definitions.Vulnerability, prob *testapi.Problem, logger *zerolog.Logger) error {
+	license, err := prob.AsSnykLicenseProblem()
+	if err != nil {
+		return fmt.Errorf("converting problem to snyk license: %w", err)
+	}
+	setBasicLicenseInfo(v, &license)
+	setEcosystem(v, &license.Ecosystem, logger)
+	setLicenseSemver(v, &license)
+	return nil
+}
+
+func setBasicLicenseInfo(v *definitions.Vulnerability, license *testapi.SnykLicenseProblem) {
+	v.CreationTime = license.CreatedAt.Format(legacyTimeFormat)
+	v.PublicationTime = util.Ptr(license.PublishedAt.Format(legacyTimeFormat))
+	v.Id = license.Id
+	v.Name = license.PackageName
+	v.Version = license.PackageVersion
+	v.Severity = definitions.VulnerabilitySeverity(license.Severity)
+	licenseType := definitions.VulnerabilityType("license")
+	v.Type = &licenseType
+	v.License = &license.License
+	v.PackageName = &license.PackageName
 }
 
 func ensureVulnHasIdentifiers(v *definitions.Vulnerability) {


### PR DESCRIPTION
What this does:

Adds missing JSON fields to vulnerabilities and license findings.  These include:
  - credit
  - fixedin
  - is_malicious
  - semver
  - socialTrendAlert
  - packageManager -- from vuln or license ecosystem based on Build vs. OS discriminator
  - publicationTime
  - version

Also adds at the project level:
  - uniqueCount -- set from the test's effective summary

Adds tests for License findings and support functions.

Chore:
  - remove Go's string encoding and HTML escaping before output, for situations like "<=" in Semver.