### PR TITLE
feat: DGP-691 - defaults OS test to use the unified Test API

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -9,7 +9,6 @@ const (
 	FlagProjectName        = "project-name"
 	FlagRiskScoreThreshold = "risk-score-threshold"
 	FlagSeverityThreshold  = "severity-threshold"
-	FlagUnifiedTestAPI     = "unified-test"
 
 	// SBOM reachability.
 	FlagReachability = "reachability"
@@ -67,7 +66,6 @@ func OSTestFlagSet() *pflag.FlagSet {
 	flagSet.String(FlagFile, "", "Specify a package file.")
 	flagSet.String(FlagProjectName, "", "Specify a name for the project.")
 
-	flagSet.Bool(FlagUnifiedTestAPI, false, "Use the unified test API workflow.")
 	flagSet.Int(FlagRiskScoreThreshold, -1, "Include findings at or over this risk score threshold.")
 	flagSet.String(FlagSeverityThreshold, "", "Report only findings at the specified level or higher.")
 


### PR DESCRIPTION
### Title:
Defaults OS test to use the unified Test API if both feature flags are present.

### What this does:

  - runs Unified Test API if user has both feature flags.
  - overrides this (by sending to legacy CLI) if env var SNYK_FORCE_LEGACY_CLI is set.

  - if the user is missing feature flags but specifies --risk-score-threshold, then throw errors about the missing FFs being required.

  - removes --unified-test param since it's now the default.

  - updates unit tests.