### PR TITLE
feat: [DGP-688] Update CLI's TestAPI to public endpoint, and reduce poll interval

### DIFF
--- a/internal/commands/ostest/ostest.go
+++ b/internal/commands/ostest/ostest.go
@@ -61,7 +61,7 @@ const LogFieldCount = "count"
 var ErrNoSummaryData = std_errors.New("no summary data to create")
 
 // PollInterval is the polling interval for the test API. It is exported to be configurable in tests.
-var PollInterval = 8 * time.Second
+var PollInterval = 2 * time.Second
 
 // RegisterWorkflows registers the "test" workflow.
 func RegisterWorkflows(e workflow.Engine) error {

--- a/internal/snykclient/snykclient.go
+++ b/internal/snykclient/snykclient.go
@@ -24,7 +24,7 @@ func (s *SnykClient) GetClient() *http.Client {
 // GetAPIBaseURL returns the API base URL.
 func (s *SnykClient) GetAPIBaseURL() string {
 	// TODO: remove this when we go GA.
-	return s.apiBaseURL + "/closed-beta/"
+	return s.apiBaseURL + "/rest/"
 }
 
 // GetOrgID returns the organization ID.


### PR DESCRIPTION
What this does:

  - updates to public test endpoint
  - changes the poll interval from every 8 secs on beta, due to rate limiting on closed beta, to every 2 seconds