### PR TITLE
Feat/low level file upload client

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -158,6 +158,7 @@ issues:
         - forcetypeassert
         - goconst
         - ireturn
+        - wrapcheck
     - path: internal/view/(.+)_test\.go
       linters:
         - testpackage

--- a/internal/fileupload/lowlevel/client.go
+++ b/internal/fileupload/lowlevel/client.go
@@ -1,0 +1,258 @@
+package lowlevel_fileupload //nolint:revive // underscore naming is intentional for this internal package
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+)
+
+// Client defines the interface for file upload API operations.
+type Client interface {
+	CreateRevision(ctx context.Context, orgID OrgID) (*UploadRevisionResponseBody, error)
+	UploadFiles(ctx context.Context, orgID OrgID, revisionID RevisionID, files []UploadFile) error
+	SealRevision(ctx context.Context, orgID OrgID, revisionID RevisionID) (*SealUploadRevisionResponseBody, error)
+}
+
+// This will force go to complain if the type doesn't satisfy the interface.
+var _ Client = (*HTTPClient)(nil)
+
+// Config contains configuration for the file upload client.
+type Config struct {
+	BaseURL string
+}
+
+// HTTPClient implements the Client interface for file upload operations via HTTP API.
+type HTTPClient struct {
+	cfg        Config
+	httpClient *http.Client
+}
+
+// APIVersion specifies the API version to use for requests.
+const APIVersion = "2024-10-15"
+
+// FileSizeLimit specifies the maximum allowed file size in bytes.
+const FileSizeLimit = 50_000_000 // arbitrary number, chosen to support max size of SBOMs
+
+// FileCountLimit specifies the maximum number of files allowed in a single upload.
+const FileCountLimit = 100 // arbitrary number, will need to be re-evaluated
+
+// ContentType is the HTTP header name for content type.
+const ContentType = "Content-Type"
+
+// NewClient creates a new file upload client with the given configuration and options.
+func NewClient(cfg Config, opts ...Opt) *HTTPClient {
+	c := HTTPClient{cfg, http.DefaultClient}
+
+	for _, opt := range opts {
+		opt(&c)
+	}
+
+	return &c
+}
+
+// CreateRevision creates a new upload revision for the specified organization.
+func (c *HTTPClient) CreateRevision(ctx context.Context, orgID OrgID) (*UploadRevisionResponseBody, error) {
+	if orgID == uuid.Nil {
+		return nil, ErrEmptyOrgID
+	}
+
+	body := UploadRevisionRequestBody{
+		Data: UploadRevisionRequestData{
+			Attributes: UploadRevisionRequestAttributes{
+				RevisionType: RevisionTypeSnapshot,
+			},
+			Type: ResourceTypeUploadRevision,
+		},
+	}
+	buff := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(buff).Encode(body); err != nil {
+		return nil, fmt.Errorf("failed to encode request body: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/hidden/orgs/%s/upload_revisions?version=%s", c.cfg.BaseURL, orgID, APIVersion)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, buff)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request body: %w", err)
+	}
+	req.Header.Set(ContentType, "application/vnd.api+json")
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making create revision request: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusCreated {
+		return nil, c.handleUnexpectedStatusCodes(res.Body, res.StatusCode, res.Status, "create upload revision")
+	}
+
+	var respBody UploadRevisionResponseBody
+	if err := json.NewDecoder(res.Body).Decode(&respBody); err != nil {
+		return nil, fmt.Errorf("failed to decode upload revision response: %w", err)
+	}
+
+	return &respBody, nil
+}
+
+// UploadFiles uploads the provided files to the specified revision. It will not close the file descriptors.
+func (c *HTTPClient) UploadFiles(ctx context.Context, orgID OrgID, revisionID RevisionID, files []UploadFile) error {
+	if orgID == uuid.Nil {
+		return ErrEmptyOrgID
+	}
+
+	if revisionID == uuid.Nil {
+		return ErrEmptyRevisionID
+	}
+
+	if len(files) > FileCountLimit {
+		return NewFileCountLimitError(len(files), FileCountLimit)
+	}
+
+	if len(files) == 0 {
+		return ErrNoFilesProvided
+	}
+
+	for _, file := range files {
+		fileInfo, err := file.File.Stat()
+		if err != nil {
+			return NewFileAccessError(file.Path, err)
+		}
+
+		if fileInfo.IsDir() {
+			return NewDirectoryError(file.Path)
+		}
+
+		if fileInfo.Size() > FileSizeLimit {
+			return NewFileSizeLimitError(file.Path, fileInfo.Size(), FileSizeLimit)
+		}
+	}
+
+	// Create pipe for streaming multipart data
+	pReader, pWriter := io.Pipe()
+	mpartWriter := multipart.NewWriter(pWriter)
+
+	// Start goroutine to write multipart data
+	go c.streamFilesToPipe(pWriter, mpartWriter, files)
+
+	// Create HTTP request with streaming body
+	url := fmt.Sprintf("%s/hidden/orgs/%s/upload_revisions/%s/files?version=%s", c.cfg.BaseURL, orgID, revisionID, APIVersion)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, pReader)
+	if err != nil {
+		pReader.Close()
+		return fmt.Errorf("failed to create upload files request: %w", err)
+	}
+
+	req.Header.Set(ContentType, mpartWriter.FormDataContentType())
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error making upload files request: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusNoContent {
+		return c.handleUnexpectedStatusCodes(res.Body, res.StatusCode, res.Status, "upload files")
+	}
+
+	return nil
+}
+
+func (c *HTTPClient) streamFilesToPipe(pWriter *io.PipeWriter, mpartWriter *multipart.Writer, files []UploadFile) {
+	var streamError error
+	defer func() {
+		pWriter.CloseWithError(streamError)
+	}()
+	defer mpartWriter.Close()
+
+	for _, file := range files {
+		// Create form file part
+		part, err := mpartWriter.CreateFormFile(file.Path, file.Path)
+		if err != nil {
+			streamError = NewMultipartError(file.Path, err)
+			return
+		}
+
+		_, err = io.Copy(part, file.File)
+		if err != nil {
+			streamError = fmt.Errorf("failed to copy file content for %s: %w", file.Path, err)
+			return
+		}
+	}
+}
+
+// SealRevision seals the specified upload revision, marking it as complete.
+func (c *HTTPClient) SealRevision(ctx context.Context, orgID OrgID, revisionID RevisionID) (*SealUploadRevisionResponseBody, error) {
+	if orgID == uuid.Nil {
+		return nil, ErrEmptyOrgID
+	}
+
+	if revisionID == uuid.Nil {
+		return nil, ErrEmptyRevisionID
+	}
+
+	body := SealUploadRevisionRequestBody{
+		Data: SealUploadRevisionRequestData{
+			ID: revisionID,
+			Attributes: SealUploadRevisionRequestAttributes{
+				Sealed: true,
+			},
+			Type: ResourceTypeUploadRevision,
+		},
+	}
+	buff := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(buff).Encode(body); err != nil {
+		return nil, fmt.Errorf("failed to encode request body: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/hidden/orgs/%s/upload_revisions/%s?version=%s", c.cfg.BaseURL, orgID, revisionID, APIVersion)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, buff)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request body: %w", err)
+	}
+	req.Header.Set(ContentType, "application/vnd.api+json")
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making seal revision request: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, c.handleUnexpectedStatusCodes(res.Body, res.StatusCode, res.Status, "seal upload revision")
+	}
+
+	var respBody SealUploadRevisionResponseBody
+	if err := json.NewDecoder(res.Body).Decode(&respBody); err != nil {
+		return nil, fmt.Errorf("failed to decode upload revision response: %w", err)
+	}
+
+	return &respBody, nil
+}
+
+func (c *HTTPClient) handleUnexpectedStatusCodes(body io.ReadCloser, statusCode int, status, operation string) error {
+	bts, err := io.ReadAll(body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if len(bts) > 0 {
+		snykErrorList, parseErr := snyk_errors.FromJSONAPIErrorBytes(bts)
+		if parseErr == nil && len(snykErrorList) > 0 && snykErrorList[0].Title != "" {
+			errsToJoin := []error{}
+			for i := range snykErrorList {
+				errsToJoin = append(errsToJoin, snykErrorList[i])
+			}
+			return fmt.Errorf("API error during %s: %w", operation, errors.Join(errsToJoin...))
+		}
+	}
+
+	return NewHTTPError(statusCode, status, operation, bts)
+}

--- a/internal/fileupload/lowlevel/client_test.go
+++ b/internal/fileupload/lowlevel/client_test.go
@@ -1,0 +1,437 @@
+package lowlevel_fileupload_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	lowlevel_fileupload "github.com/snyk/cli-extension-os-flows/internal/fileupload/lowlevel"
+)
+
+func TestClient_CreateRevision(t *testing.T) {
+	orgID := uuid.MustParse("9102b78b-c28d-4392-a39f-08dd26fd9622")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/vnd.api+json", r.Header.Get("Content-Type"))
+		assert.Equal(t, fmt.Sprintf("/hidden/orgs/%s/upload_revisions", orgID), r.URL.Path)
+		assert.Equal(t, "2024-10-15", r.URL.Query().Get("version"))
+
+		w.WriteHeader(http.StatusCreated)
+		//nolint:errcheck // Not needed in test.
+		w.Write([]byte(`{
+			"data": {
+				"attributes": {
+					"revision_type": "snapshot",
+					"sealed": false
+				},
+				"id": "a7d975fb-2076-49b7-bc1f-31c395c3ce93",
+				"type": "upload_revision"
+			}
+		}`))
+	}))
+	c := lowlevel_fileupload.NewClient(lowlevel_fileupload.Config{
+		BaseURL: srv.URL,
+	})
+
+	resp, err := c.CreateRevision(context.Background(), orgID)
+
+	require.NoError(t, err)
+	expectedID := uuid.MustParse("a7d975fb-2076-49b7-bc1f-31c395c3ce93")
+	assert.Equal(t, expectedID, resp.Data.ID)
+}
+
+func TestClient_CreateRevision_EmptyOrgID(t *testing.T) {
+	c := lowlevel_fileupload.NewClient(lowlevel_fileupload.Config{
+		BaseURL: "http://example.com",
+	})
+
+	resp, err := c.CreateRevision(context.Background(), uuid.Nil)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, lowlevel_fileupload.ErrEmptyOrgID)
+}
+
+func TestClient_CreateRevision_ServerError(t *testing.T) {
+	orgID := uuid.MustParse("9102b78b-c28d-4392-a39f-08dd26fd9622")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	c := lowlevel_fileupload.NewClient(lowlevel_fileupload.Config{
+		BaseURL: srv.URL,
+	})
+
+	resp, err := c.CreateRevision(context.Background(), orgID)
+
+	assert.Nil(t, resp)
+	var httpErr *lowlevel_fileupload.HTTPError
+	assert.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
+	assert.Equal(t, "create upload revision", httpErr.Operation)
+}
+
+func TestClient_UploadFiles(t *testing.T) {
+	orgID := uuid.MustParse("9102b78b-c28d-4392-a39f-08dd26fd9622")
+	revID := uuid.MustParse("ff1bd2c6-7a5f-48fb-9a5b-52d711c8b47f")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.Header.Get("Content-Type"), "multipart/form-data")
+		assert.Equal(t, fmt.Sprintf("/hidden/orgs/%s/upload_revisions/%s/files", orgID, revID), r.URL.Path)
+		assert.Equal(t, "2024-10-15", r.URL.Query().Get("version"))
+
+		// Parse multipart form data
+		contentType := r.Header.Get("Content-Type")
+		_, params, err := mime.ParseMediaType(contentType)
+		require.NoError(t, err)
+		boundary := params["boundary"]
+		require.NotEmpty(t, boundary, "multipart boundary should be present")
+
+		reader := multipart.NewReader(r.Body, boundary)
+
+		// Read the first (and should be only) part
+		part, err := reader.NextPart()
+		require.NoError(t, err)
+
+		// Validate form field name and filename
+		assert.Equal(t, "foo/bar", part.FormName())
+		assert.Equal(t, "bar", part.FileName()) // filename is just the base name
+
+		// Read and validate file content
+		content, err := io.ReadAll(part)
+		require.NoError(t, err)
+		assert.Equal(t, "asdf", string(content))
+
+		// Ensure no more parts
+		_, err = reader.NextPart()
+		assert.Equal(t, io.EOF, err)
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := lowlevel_fileupload.NewClient(lowlevel_fileupload.Config{
+		BaseURL: srv.URL,
+	})
+
+	mockFS := fstest.MapFS{
+		"foo/bar": {Data: []byte("asdf")},
+	}
+	fd, err := mockFS.Open("foo/bar")
+	require.NoError(t, err)
+
+	err = c.UploadFiles(context.Background(),
+		orgID,
+		revID,
+		[]lowlevel_fileupload.UploadFile{
+			{Path: "foo/bar", File: fd},
+		})
+
+	require.NoError(t, err)
+}
+
+func TestClient_UploadFiles_MultipleFiles(t *testing.T) {
+	orgID := uuid.MustParse("9102b78b-c28d-4392-a39f-08dd26fd9622")
+	revID := uuid.MustParse("ff1bd2c6-7a5f-48fb-9a5b-52d711c8b47f")
+	expectedFiles := map[string]string{
+		"file1.txt":  "content1",
+		"file2.json": "content2",
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.Header.Get("Content-Type"), "multipart/form-data")
+		assert.Equal(t, fmt.Sprintf("/hidden/orgs/%s/upload_revisions/%s/files", orgID, revID), r.URL.Path)
+		assert.Equal(t, "2024-10-15", r.URL.Query().Get("version"))
+
+		// Parse multipart form data
+		contentType := r.Header.Get("Content-Type")
+		_, params, err := mime.ParseMediaType(contentType)
+		require.NoError(t, err)
+		boundary := params["boundary"]
+		require.NotEmpty(t, boundary, "multipart boundary should be present")
+
+		reader := multipart.NewReader(r.Body, boundary)
+		filesReceived := make(map[string]string)
+
+		// Read all parts
+		for {
+			part, err := reader.NextPart()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			require.NoError(t, err)
+
+			// Read content
+			content, err := io.ReadAll(part)
+			require.NoError(t, err)
+
+			// Store for validation (use form name which is the full path)
+			filesReceived[part.FormName()] = string(content)
+		}
+
+		// Validate all expected files were received
+		assert.Equal(t, expectedFiles, filesReceived)
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := lowlevel_fileupload.NewClient(lowlevel_fileupload.Config{
+		BaseURL: srv.URL,
+	})
+
+	mockFS := fstest.MapFS{
+		"file1.txt":  {Data: []byte("content1")},
+		"file2.json": {Data: []byte("content2")},
+	}
+
+	file1, err := mockFS.Open("file1.txt")
+	require.NoError(t, err)
+	file2, err := mockFS.Open("file2.json")
+	require.NoError(t, err)
+
+	err = c.UploadFiles(context.Background(),
+		orgID,
+		revID,
+		[]lowlevel_fileupload.UploadFile{
+			{Path: "file1.txt", File: file1},
+			{Path: "file2.json", File: file2},
+		})
+
+	require.NoError(t, err)
+}
+
+func TestClient_UploadFiles_EmptyOrgID(t *testing.T) {
+	revID := uuid.MustParse("ff1bd2c6-7a5f-48fb-9a5b-52d711c8b47f")
+
+	c := lowlevel_fileupload.NewClient(lowlevel_fileupload.Config{
+		BaseURL: "http://example.com",
+	})
+
+	mockFS := fstest.MapFS{
+		"test.txt": {Data: []byte("content")},
+	}
+	file, err := mockFS.Open("test.txt")
+	require.NoError(t, err)
+
+	err = c.UploadFiles(context.Background(),
+		uuid.Nil, // empty orgID
+		revID,
+		[]lowlevel_fileupload.UploadFile{
+			{Path: "test.txt", File: file},
+		})
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, lowlevel_fileupload.ErrEmptyOrgID)
+}
+
+func TestClient_UploadFiles_EmptyRevisionID(t *testing.T) {
+	orgID := uuid.MustParse("9102b78b-c28d-4392-a39f-08dd26fd9622")
+
+	c := lowlevel_fileupload.NewClient(lowlevel_fileupload.Config{
+		BaseURL: "http://example.com",
+	})
+
+	mockFS := fstest.MapFS{
+		"test.txt": {Data: []byte("content")},
+	}
+	file, err := mockFS.Open("test.txt")
+	require.NoError(t, err)
+
+	err = c.UploadFiles(context.Background(),
+		orgID,
+		uuid.Nil, // empty revisionID
+		[]lowlevel_fileupload.UploadFile{
+			{Path: "test.txt", File: file},
+		})
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, lowlevel_fileupload.ErrEmptyRevisionID)
+}
+
+func TestClient_UploadFiles_FileSizeLimit(t *testing.T) {
+	orgID := uuid.MustParse("9102b78b-c28d-4392-a39f-08dd26fd9622")
+	revID := uuid.MustParse("ff1bd2c6-7a5f-48fb-9a5b-52d711c8b47f")
+
+	c := lowlevel_fileupload.NewClient(lowlevel_fileupload.Config{
+		BaseURL: "http://example.com",
+	})
+
+	largeContent := make([]byte, lowlevel_fileupload.FileSizeLimit+1)
+	mockFS := fstest.MapFS{
+		"large_file.txt": {Data: largeContent},
+	}
+
+	file, err := mockFS.Open("large_file.txt")
+	require.NoError(t, err)
+
+	err = c.UploadFiles(context.Background(),
+		orgID,
+		revID,
+		[]lowlevel_fileupload.UploadFile{
+			{Path: "large_file.txt", File: file},
+		})
+
+	assert.Error(t, err)
+	var fileSizeErr *lowlevel_fileupload.FileSizeLimitError
+	assert.ErrorAs(t, err, &fileSizeErr)
+	assert.Equal(t, "large_file.txt", fileSizeErr.FileName)
+	assert.Equal(t, int64(lowlevel_fileupload.FileSizeLimit+1), fileSizeErr.FileSize)
+	assert.Equal(t, int64(lowlevel_fileupload.FileSizeLimit), fileSizeErr.Limit)
+}
+
+func TestClient_UploadFiles_FileCountLimit(t *testing.T) {
+	orgID := uuid.MustParse("9102b78b-c28d-4392-a39f-08dd26fd9622")
+	revID := uuid.MustParse("ff1bd2c6-7a5f-48fb-9a5b-52d711c8b47f")
+
+	c := lowlevel_fileupload.NewClient(lowlevel_fileupload.Config{
+		BaseURL: "http://example.com",
+	})
+
+	files := make([]lowlevel_fileupload.UploadFile, lowlevel_fileupload.FileCountLimit+1)
+	mockFS := fstest.MapFS{}
+
+	for i := range lowlevel_fileupload.FileCountLimit + 1 {
+		filename := fmt.Sprintf("file%d.txt", i)
+		mockFS[filename] = &fstest.MapFile{Data: []byte("content")}
+
+		file, err := mockFS.Open(filename)
+		require.NoError(t, err)
+
+		files[i] = lowlevel_fileupload.UploadFile{
+			Path: filename,
+			File: file,
+		}
+	}
+
+	err := c.UploadFiles(context.Background(), orgID, revID, files)
+
+	assert.Error(t, err)
+	var fileCountErr *lowlevel_fileupload.FileCountLimitError
+	assert.ErrorAs(t, err, &fileCountErr)
+	assert.Equal(t, lowlevel_fileupload.FileCountLimit+1, fileCountErr.Count)
+	assert.Equal(t, lowlevel_fileupload.FileCountLimit, fileCountErr.Limit)
+}
+
+func TestClient_UploadFiles_DirectoryError(t *testing.T) {
+	orgID := uuid.MustParse("9102b78b-c28d-4392-a39f-08dd26fd9622")
+	revID := uuid.MustParse("ff1bd2c6-7a5f-48fb-9a5b-52d711c8b47f")
+
+	c := lowlevel_fileupload.NewClient(lowlevel_fileupload.Config{
+		BaseURL: "http://example.com",
+	})
+
+	mockFS := fstest.MapFS{
+		"test-directory": &fstest.MapFile{
+			Mode: fs.ModeDir,
+		},
+	}
+
+	dirFile, err := mockFS.Open("test-directory")
+	require.NoError(t, err)
+
+	err = c.UploadFiles(context.Background(),
+		orgID,
+		revID,
+		[]lowlevel_fileupload.UploadFile{
+			{Path: "test-directory", File: dirFile},
+		})
+
+	assert.Error(t, err)
+	var dirErr *lowlevel_fileupload.DirectoryError
+	assert.ErrorAs(t, err, &dirErr)
+	assert.Equal(t, "test-directory", dirErr.Path)
+}
+
+func TestClient_UploadFiles_EmptyFileList(t *testing.T) {
+	orgID := uuid.MustParse("9102b78b-c28d-4392-a39f-08dd26fd9622")
+	revID := uuid.MustParse("ff1bd2c6-7a5f-48fb-9a5b-52d711c8b47f")
+
+	c := lowlevel_fileupload.NewClient(lowlevel_fileupload.Config{
+		BaseURL: "http://example.com",
+	})
+
+	err := c.UploadFiles(context.Background(), orgID, revID, []lowlevel_fileupload.UploadFile{})
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, lowlevel_fileupload.ErrNoFilesProvided)
+}
+
+func TestClient_SealRevision(t *testing.T) {
+	orgID := uuid.MustParse("9102b78b-c28d-4392-a39f-08dd26fd9622")
+	revID := uuid.MustParse("ff1bd2c6-7a5f-48fb-9a5b-52d711c8b47f")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "application/vnd.api+json", r.Header.Get("Content-Type"))
+		assert.Equal(t, fmt.Sprintf("/hidden/orgs/%s/upload_revisions/%s", orgID, revID), r.URL.Path)
+		assert.Equal(t, "2024-10-15", r.URL.Query().Get("version"))
+
+		w.WriteHeader(http.StatusOK)
+		//nolint:errcheck // Not needed in test.
+		w.Write([]byte(`{
+			"data": {
+				"attributes": {
+					"revision_type": "snapshot",
+					"sealed": true
+				},
+				"id": "ff1bd2c6-7a5f-48fb-9a5b-52d711c8b47f",
+				"type": "upload_revision"
+			}
+		}`))
+	}))
+	c := lowlevel_fileupload.NewClient(lowlevel_fileupload.Config{
+		BaseURL: srv.URL,
+	})
+
+	resp, err := c.SealRevision(context.Background(), orgID, revID)
+
+	require.NoError(t, err)
+	assert.Equal(t, revID, resp.Data.ID)
+	assert.True(t, resp.Data.Attributes.Sealed)
+}
+
+func TestClient_SealRevision_EmptyOrgID(t *testing.T) {
+	revID := uuid.MustParse("ff1bd2c6-7a5f-48fb-9a5b-52d711c8b47f")
+
+	c := lowlevel_fileupload.NewClient(lowlevel_fileupload.Config{
+		BaseURL: "http://example.com",
+	})
+
+	resp, err := c.SealRevision(context.Background(),
+		uuid.Nil, // empty orgID
+		revID,
+	)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, lowlevel_fileupload.ErrEmptyOrgID)
+	assert.Nil(t, resp)
+}
+
+func TestClient_SealRevision_EmptyRevisionID(t *testing.T) {
+	orgID := uuid.MustParse("9102b78b-c28d-4392-a39f-08dd26fd9622")
+
+	c := lowlevel_fileupload.NewClient(lowlevel_fileupload.Config{
+		BaseURL: "http://example.com",
+	})
+
+	resp, err := c.SealRevision(context.Background(),
+		orgID,
+		uuid.Nil, // empty revisionID
+	)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, lowlevel_fileupload.ErrEmptyRevisionID)
+	assert.Nil(t, resp)
+}

--- a/internal/fileupload/lowlevel/errors.go
+++ b/internal/fileupload/lowlevel/errors.go
@@ -1,0 +1,133 @@
+package lowlevel_fileupload //nolint:revive // underscore naming is intentional for this internal package
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors for common conditions.
+var (
+	ErrNoFilesProvided = errors.New("no files provided for upload")
+	ErrEmptyOrgID      = errors.New("organization ID cannot be empty")
+	ErrEmptyRevisionID = errors.New("revision ID cannot be empty")
+)
+
+// FileSizeLimitError indicates a file exceeds the maximum allowed size.
+type FileSizeLimitError struct {
+	FileName string
+	FileSize int64
+	Limit    int64
+}
+
+func (e *FileSizeLimitError) Error() string {
+	return fmt.Sprintf("file %s size %d exceeds limit of %d bytes", e.FileName, e.FileSize, e.Limit)
+}
+
+// FileCountLimitError indicates too many files were provided.
+type FileCountLimitError struct {
+	Count int
+	Limit int
+}
+
+func (e *FileCountLimitError) Error() string {
+	return fmt.Sprintf("too many files: %d exceeds limit of %d", e.Count, e.Limit)
+}
+
+// FileAccessError indicates a file cannot be accessed or read.
+type FileAccessError struct {
+	FileName string
+	Err      error
+}
+
+func (e *FileAccessError) Error() string {
+	return fmt.Sprintf("file %s cannot be accessed: %v", e.FileName, e.Err)
+}
+
+func (e *FileAccessError) Unwrap() error {
+	return e.Err
+}
+
+// DirectoryError indicates a path points to a directory instead of a file.
+type DirectoryError struct {
+	Path string
+}
+
+func (e *DirectoryError) Error() string {
+	return fmt.Sprintf("path %s is a directory, not a file", e.Path)
+}
+
+// HTTPError represents an HTTP error response.
+type HTTPError struct {
+	StatusCode int
+	Status     string
+	Operation  string
+	Body       []byte
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("unsuccessful request to %s: %s", e.Operation, e.Status)
+}
+
+// MultipartError indicates an error creating multipart form data.
+type MultipartError struct {
+	FileName string
+	Err      error
+}
+
+func (e *MultipartError) Error() string {
+	return fmt.Sprintf("failed to create multipart form for %s: %v", e.FileName, e.Err)
+}
+
+func (e *MultipartError) Unwrap() error {
+	return e.Err
+}
+
+// NewFileSizeLimitError creates a new FileSizeLimitError with the given parameters.
+func NewFileSizeLimitError(fileName string, fileSize, limit int64) *FileSizeLimitError {
+	return &FileSizeLimitError{
+		FileName: fileName,
+		FileSize: fileSize,
+		Limit:    limit,
+	}
+}
+
+// NewFileCountLimitError creates a new FileCountLimitError with the given parameters.
+func NewFileCountLimitError(count, limit int) *FileCountLimitError {
+	return &FileCountLimitError{
+		Count: count,
+		Limit: limit,
+	}
+}
+
+// NewFileAccessError creates a new FileAccessError with the given parameters.
+func NewFileAccessError(fileName string, err error) *FileAccessError {
+	return &FileAccessError{
+		FileName: fileName,
+		Err:      err,
+	}
+}
+
+// NewDirectoryError creates a new DirectoryError with the given path.
+func NewDirectoryError(path string) *DirectoryError {
+	return &DirectoryError{
+		Path: path,
+	}
+}
+
+// NewHTTPError creates a new HTTPError with the given parameters.
+func NewHTTPError(statusCode int, status, operation string, body []byte) *HTTPError {
+	return &HTTPError{
+		StatusCode: statusCode,
+		Status:     status,
+		Operation:  operation,
+		Body:       body,
+	}
+}
+
+// NewMultipartError creates a new MultipartError with the given parameters.
+func NewMultipartError(fileName string, err error) *MultipartError {
+	return &MultipartError{
+		FileName: fileName,
+		Err:      err,
+	}
+}

--- a/internal/fileupload/lowlevel/opts.go
+++ b/internal/fileupload/lowlevel/opts.go
@@ -1,0 +1,13 @@
+package lowlevel_fileupload //nolint:revive // underscore naming is intentional for this internal package
+
+import "net/http"
+
+// Opt is a function that configures an HTTPClient instance.
+type Opt func(*HTTPClient)
+
+// WithHTTPClient sets a custom HTTP client for the file upload client.
+func WithHTTPClient(httpClient *http.Client) Opt {
+	return func(c *HTTPClient) {
+		c.httpClient = httpClient
+	}
+}

--- a/internal/fileupload/lowlevel/opts_test.go
+++ b/internal/fileupload/lowlevel/opts_test.go
@@ -1,0 +1,47 @@
+package lowlevel_fileupload_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	lowlevel_fileupload "github.com/snyk/cli-extension-os-flows/internal/fileupload/lowlevel"
+)
+
+type CustomRoundTripper struct{}
+
+func (crt *CustomRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.Header.Set("foo", "bar")
+	return http.DefaultTransport.RoundTrip(r)
+}
+
+func Test_WithHTTPClient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fooValue := r.Header.Get("foo")
+		assert.Equal(t, "bar", fooValue)
+
+		resp, err := json.Marshal(lowlevel_fileupload.UploadRevisionResponseBody{})
+		require.NoError(t, err)
+
+		w.WriteHeader(http.StatusCreated)
+		//nolint:errcheck // Not needed in test.
+		w.Write(resp)
+	}))
+	defer srv.Close()
+	customClient := srv.Client()
+	customClient.Transport = &CustomRoundTripper{}
+
+	llc := lowlevel_fileupload.NewClient(lowlevel_fileupload.Config{
+		BaseURL: srv.URL,
+	}, lowlevel_fileupload.WithHTTPClient(customClient))
+
+	_, err := llc.CreateRevision(context.Background(), uuid.New())
+
+	require.NoError(t, err)
+}

--- a/internal/fileupload/lowlevel/types.go
+++ b/internal/fileupload/lowlevel/types.go
@@ -1,0 +1,117 @@
+package lowlevel_fileupload //nolint:revive // underscore naming is intentional for this internal package
+
+import (
+	"io/fs"
+
+	"github.com/google/uuid"
+)
+
+// OrgID represents an organization identifier.
+type OrgID = uuid.UUID
+
+// RevisionID represents a revision identifier.
+type RevisionID = uuid.UUID
+
+// RevisionType represents the type of revision being created.
+type RevisionType string
+
+const (
+	// RevisionTypeSnapshot represents a snapshot revision type.
+	RevisionTypeSnapshot RevisionType = "snapshot"
+)
+
+// ResourceType represents the type of resource in API requests.
+type ResourceType string
+
+const (
+	// ResourceTypeUploadRevision represents an upload revision resource type.
+	ResourceTypeUploadRevision ResourceType = "upload_revision"
+)
+
+// UploadRevisionRequestAttributes contains the attributes for creating an upload revision.
+type UploadRevisionRequestAttributes struct {
+	RevisionType RevisionType `json:"revision_type"` //nolint:tagliatelle // API expects snake_case
+}
+
+// UploadRevisionRequestData contains the data payload for creating an upload revision.
+type UploadRevisionRequestData struct {
+	Attributes UploadRevisionRequestAttributes `json:"attributes"`
+	Type       ResourceType                    `json:"type"`
+}
+
+// UploadRevisionRequestBody contains the complete request body for creating an upload revision.
+type UploadRevisionRequestBody struct {
+	Data UploadRevisionRequestData `json:"data"`
+}
+
+// UploadRevisionResponseAttributes contains the attributes returned when creating an upload revision.
+type UploadRevisionResponseAttributes struct {
+	RevisionType RevisionType `json:"revision_type"` //nolint:tagliatelle // API expects snake_case
+	Sealed       bool         `json:"sealed"`
+}
+
+// UploadRevisionResponseData contains the data returned when creating an upload revision.
+type UploadRevisionResponseData struct {
+	ID         RevisionID                       `json:"id"`
+	Type       ResourceType                     `json:"type"`
+	Attributes UploadRevisionResponseAttributes `json:"attributes"`
+}
+
+// UploadRevisionResponseBody contains the complete response body when creating an upload revision.
+type UploadRevisionResponseBody struct {
+	Data UploadRevisionResponseData `json:"data"`
+}
+
+// SealUploadRevisionRequestAttributes contains the attributes for sealing an upload revision.
+type SealUploadRevisionRequestAttributes struct {
+	Sealed bool `json:"sealed"`
+}
+
+// SealUploadRevisionRequestData contains the data payload for sealing an upload revision.
+type SealUploadRevisionRequestData struct {
+	ID         RevisionID                          `json:"id"`
+	Type       ResourceType                        `json:"type"`
+	Attributes SealUploadRevisionRequestAttributes `json:"attributes"`
+}
+
+// SealUploadRevisionRequestBody contains the complete request body for sealing an upload revision.
+type SealUploadRevisionRequestBody struct {
+	Data SealUploadRevisionRequestData `json:"data"`
+}
+
+// SealUploadRevisionResponseAttributes contains the attributes returned when sealing an upload revision.
+type SealUploadRevisionResponseAttributes struct {
+	RevisionType RevisionType `json:"revision_type"` //nolint:tagliatelle // API expects snake_case
+	Sealed       bool         `json:"sealed"`
+}
+
+// SealUploadRevisionResponseData contains the data returned when sealing an upload revision.
+type SealUploadRevisionResponseData struct {
+	ID         RevisionID                           `json:"id"`
+	Type       ResourceType                         `json:"type"`
+	Attributes SealUploadRevisionResponseAttributes `json:"attributes"`
+}
+
+// SealUploadRevisionResponseBody contains the complete response body when sealing an upload revision.
+type SealUploadRevisionResponseBody struct {
+	Data SealUploadRevisionResponseData `json:"data"`
+}
+
+// ResponseError represents an error in an API response.
+type ResponseError struct {
+	ID     string `json:"id"`
+	Title  string `json:"title"`
+	Status string `json:"status"`
+	Detail string `json:"detail"`
+}
+
+// ErrorResponseBody contains the complete error response body.
+type ErrorResponseBody struct {
+	Errors []ResponseError `json:"errors"`
+}
+
+// UploadFile represents a file to be uploaded, containing both the path and file handle.
+type UploadFile struct {
+	Path string // The name to use for the file in the upload
+	File fs.File
+}


### PR DESCRIPTION
# What this does?

Adds a **low** level client for the File Upload API. It offers an interface to:
* Create an upload revision
* Upload a chunk of files to a revision
* Seal an upload revision

# What it doesn't do

This client does not handle:
* File discovery in a directory
* Chunking the requests based on size or number of files provided
* Filtering uploaded files based on `deeproxy` filters.

All of the above are in the scope of a **high** level client.