### PR TITLE
fix: add github security advisory problems to legacy vuln info

### DIFF
--- a/internal/legacy/transform/transform.go
+++ b/internal/legacy/transform/transform.go
@@ -53,6 +53,8 @@ func ProcessProblemForVuln(
 		return processCveProblem(vuln, prob)
 	case string(testapi.Cwe):
 		return processCweProblem(vuln, prob)
+	case string(testapi.Ghsa):
+		return processGhsaProblem(vuln, prob)
 	case string(testapi.SnykLicense):
 		return processSnykLicenseProblem(vuln, prob, logger)
 	default:
@@ -383,6 +385,19 @@ func processCweProblem(v *definitions.Vulnerability, prob *testapi.Problem) erro
 		return fmt.Errorf("converting problem to cwe: %w", err)
 	}
 	v.Identifiers.CWE = append(v.Identifiers.CWE, cwe.Id)
+	return nil
+}
+
+func processGhsaProblem(v *definitions.Vulnerability, prob *testapi.Problem) error {
+	ensureVulnHasIdentifiers(v)
+	ghsa, err := prob.AsGithubSecurityAdvisoryProblem()
+	if err != nil {
+		return fmt.Errorf("converting problem to github security advisory: %w", err)
+	}
+	if v.Identifiers.GHSA == nil {
+		v.Identifiers.GHSA = &[]string{}
+	}
+	*v.Identifiers.GHSA = append(*v.Identifiers.GHSA, ghsa.Id)
 	return nil
 }
 

--- a/internal/legacy/transform/transform_test.go
+++ b/internal/legacy/transform/transform_test.go
@@ -25,6 +25,10 @@ func TestProcessProblemForVuln_Identifiers(t *testing.T) {
 	err = cweProblem.FromCweProblem(testapi.CweProblem{Id: "cwe-problem-id", Source: testapi.Cwe})
 	require.NoError(t, err)
 
+	ghsaProblem := &testapi.Problem{}
+	err = ghsaProblem.FromGithubSecurityAdvisoryProblem(testapi.GithubSecurityAdvisoryProblem{Id: "ghsa-problem-id", Source: testapi.Ghsa})
+	require.NoError(t, err)
+
 	// Setup invalid problem
 	malformedProblem := &testapi.Problem{} // empty union
 
@@ -56,6 +60,18 @@ func TestProcessProblemForVuln_Identifiers(t *testing.T) {
 				require.NotNil(t, v.Identifiers)
 				require.Len(t, v.Identifiers.CWE, 1)
 				assert.Equal(t, "cwe-problem-id", v.Identifiers.CWE[0])
+				require.Len(t, v.Identifiers.CVE, 0)
+			},
+		},
+		{
+			name:    "should add GHSA identifier to empty vulnerability",
+			vuln:    &definitions.Vulnerability{},
+			problem: ghsaProblem,
+			assertFunc: func(t *testing.T, v *definitions.Vulnerability) {
+				t.Helper()
+				require.NotNil(t, v.Identifiers)
+				require.Len(t, *v.Identifiers.GHSA, 1)
+				assert.Equal(t, "ghsa-problem-id", (*v.Identifiers.GHSA)[0])
 				require.Len(t, v.Identifiers.CVE, 0)
 			},
 		},


### PR DESCRIPTION
This maps GHSA problems back onto legacy JSON output.