### PR TITLE
fix: provide output when there are no vulns found

### DIFF
--- a/internal/commands/ostest/workflow_test.go
+++ b/internal/commands/ostest/workflow_test.go
@@ -532,9 +532,9 @@ func TestOSWorkflow_AllProjects_UnifiedFlow(t *testing.T) {
 		}
 	}
 
-	// Should have 1 JSON output (as an array of results) and 0 summary outputs (since there are no findings)
+	// Should have 1 JSON output (as an array of results) and 2 summary outputs (no findings, empty summaries)
 	assert.Len(t, jsonOutputs, 1)
-	assert.Len(t, summaryOutputs, 0)
+	assert.Len(t, summaryOutputs, 2)
 
 	// Verify JSON output is an array of 2 results
 	var legacyResults []definitions.LegacyVulnerabilityResponse


### PR DESCRIPTION
OS test workflow was providing no output and exit code 0 when no vulns were found.

This displays a sensible summary indicating no vulnerabilities in the human readable output.

- [X] TODO: update failing tests

Example output, using a CLI build using this branch, testing a side project of mine that is super-secure with no vulns:

```
c@m1a1 onionpipe % snyk-macos-arm64 test

Testing /Users/c/Projects/onionpipe ...

Tested 22 dependencies for known issues, found 0 issues, 0 vulnerable paths.

╭─────────────────────────────────────────────────────╮
│ Test Summary                                        │
│                                                     │
│   Organization:      test-api-shim                  │
│   Test type:         open-source                    │
│   Project path:      /Users/c/Projects/onionpipe    │
│                                                     │
│   Total issues:   0                                 │
╰─────────────────────────────────────────────────────╯
💡 Tip

   To view ignored issues, use the --include-ignores option.


c@m1a1 onionpipe % echo $?
0
```

It's consistent with non-empty output and so I think it is reasonable.