### PR TITLE
feat: include organization slug in the legacy JSON output

### DIFF
--- a/internal/commands/ostest/__snapshots__/sbom_reachability_flow_test.snap
+++ b/internal/commands/ostest/__snapshots__/sbom_reachability_flow_test.snap
@@ -21,7 +21,7 @@
   "severities": null
  },
  "ok": false,
- "org": "",
+ "org": "test-org-slug",
  "packageManager": "",
  "policy": "",
  "projectName": "",

--- a/internal/commands/ostest/depgraph_flow.go
+++ b/internal/commands/ostest/depgraph_flow.go
@@ -28,6 +28,7 @@ func RunUnifiedTestFlow(
 	riskScoreThreshold *uint16,
 	severityThreshold *testapi.Severity,
 	orgID string,
+	orgSlugOrID string,
 	errFactory *errors.ErrorFactory,
 	logger *zerolog.Logger,
 ) ([]workflow.Data, error) {
@@ -46,6 +47,7 @@ func RunUnifiedTestFlow(
 		ictx,
 		testClient,
 		orgID,
+		orgSlugOrID,
 		errFactory,
 		logger,
 		localPolicy,
@@ -65,6 +67,7 @@ func testAllDepGraphs(
 	ictx workflow.InvocationContext,
 	testClient testapi.TestClient,
 	orgID string,
+	orgSlugOrID string,
 	errFactory *errors.ErrorFactory,
 	logger *zerolog.Logger,
 	localPolicy *testapi.LocalPolicy,
@@ -92,7 +95,7 @@ func testAllDepGraphs(
 		// Run the test with the depgraph subject
 		legacyFinding, outputData, err := RunTest(
 			ctx, ictx, testClient, subject, projectName, packageManager, depCount,
-			displayTargetFile, orgID, errFactory, logger, localPolicy)
+			displayTargetFile, orgID, orgSlugOrID, errFactory, logger, localPolicy)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/commands/ostest/sbom_reachability_flow.go
+++ b/internal/commands/ostest/sbom_reachability_flow.go
@@ -26,6 +26,7 @@ func RunSbomReachabilityFlow(
 	sourceCodePath string,
 	bsClient bundlestore.Client,
 	orgID string,
+	orgSlugOrID string,
 ) ([]workflow.Data, error) {
 	if sourceCodePath == "" {
 		sourceCodePath = "."
@@ -68,7 +69,7 @@ func RunSbomReachabilityFlow(
 		return nil, fmt.Errorf("failed to create sbom test reachability subject: %w", err)
 	}
 
-	findings, summary, err := RunTest(ctx, ictx, testClient, subject, "", "", int(0), "", orgID, errFactory, logger, nil)
+	findings, summary, err := RunTest(ctx, ictx, testClient, subject, "", "", int(0), "", orgID, orgSlugOrID, errFactory, logger, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/commands/ostest/sbom_reachability_flow_test.go
+++ b/internal/commands/ostest/sbom_reachability_flow_test.go
@@ -37,6 +37,7 @@ func Test_RunSbomReachabilityFlow_Success(t *testing.T) {
 	sbomPath := "./testdata/bom.json"
 	sourceCodePath := "./testdata/test_dir"
 	orgID := "test-org-id"
+	orgSlug := "test-org-slug"
 
 	vulnTime, err := time.Parse(time.RFC3339, "2025-07-28T17:11:43+03:00")
 	require.NoError(t, err)
@@ -156,14 +157,15 @@ func Test_RunSbomReachabilityFlow_Success(t *testing.T) {
 	mockBsClient.EXPECT().UploadSBOM(ctx, sbomPath).Return("test-sbom-hash", nil).Times(1)
 	mockBsClient.EXPECT().UploadSourceCode(ctx, sourceCodePath).Return("test-source-hash", nil).Times(1)
 
-	// Mock Invocation COntext
+	// Mock Invocation Context
 	mockConfig := configuration.New()
 	mockConfig.Set(outputworkflow.OutputConfigKeyJSON, true)
+	mockConfig.Set(configuration.ORGANIZATION_SLUG, orgSlug)
 	mockIctx := gafmocks.NewMockInvocationContext(ctrl)
-	mockIctx.EXPECT().GetConfiguration().Return(mockConfig).Times(1)
+	mockIctx.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
 
 	// This should now succeed with proper finding data
-	result, err := ostest.RunSbomReachabilityFlow(ctx, mockIctx, mockTestClient, ef, &logger, sbomPath, sourceCodePath, mockBsClient, orgID)
+	result, err := ostest.RunSbomReachabilityFlow(ctx, mockIctx, mockTestClient, ef, &logger, sbomPath, sourceCodePath, mockBsClient, orgID, orgSlug)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)

--- a/internal/commands/ostest/test_execution.go
+++ b/internal/commands/ostest/test_execution.go
@@ -43,6 +43,7 @@ func RunTest(
 	depCount int,
 	displayTargetFile string,
 	orgID string,
+	orgSlugOrID string,
 	errFactory *errors.ErrorFactory,
 	logger *zerolog.Logger,
 	localPolicy *testapi.LocalPolicy,
@@ -71,6 +72,7 @@ func RunTest(
 	legacyParams := &transform.SnykSchemaToLegacyParams{
 		Findings:          findingsData,
 		TestResult:        finalResult,
+		OrgSlugOrID:       orgSlugOrID,
 		ProjectName:       projectName,
 		PackageManager:    packageManager,
 		CurrentDir:        currentDir,

--- a/internal/commands/ostest/workflow_test.go
+++ b/internal/commands/ostest/workflow_test.go
@@ -248,6 +248,7 @@ func createMockInvocationCtxWithURL(t *testing.T, ctrl *gomock.Controller, engin
 	mockConfig := configuration.New()
 	mockConfig.Set(configuration.AUTHENTICATION_TOKEN, "<SOME API TOKEN>")
 	mockConfig.Set(configuration.ORGANIZATION, uuid.New().String())
+	mockConfig.Set(configuration.ORGANIZATION_SLUG, "some-org")
 	mockConfig.Set(configuration.API_URL, mockServerURL)
 
 	// Initialize with default values for our flags

--- a/internal/legacy/transform/transform.go
+++ b/internal/legacy/transform/transform.go
@@ -24,6 +24,7 @@ const (
 type SnykSchemaToLegacyParams struct {
 	Findings          []testapi.FindingData
 	TestResult        testapi.TestResult
+	OrgSlugOrID       string
 	ProjectName       string
 	PackageManager    string
 	CurrentDir        string
@@ -348,6 +349,7 @@ func ConvertSnykSchemaFindingsToLegacy(params *SnykSchemaToLegacyParams) (*defin
 	}
 
 	res := definitions.LegacyVulnerabilityResponse{
+		Org:               params.OrgSlugOrID,
 		ProjectName:       params.ProjectName,
 		Path:              params.CurrentDir,
 		PackageManager:    params.PackageManager,


### PR DESCRIPTION
  - if slug is unavailable, it adds the org ID instead.
  - updates legacy test output