### PR TITLE
feat: show target directory and target file

### DIFF
--- a/internal/commands/ostest/depgraph_flow.go
+++ b/internal/commands/ostest/depgraph_flow.go
@@ -28,7 +28,6 @@ func RunUnifiedTestFlow(
 	riskScoreThreshold *uint16,
 	severityThreshold *testapi.Severity,
 	orgID string,
-	orgSlugOrID string,
 	errFactory *errors.ErrorFactory,
 	logger *zerolog.Logger,
 ) ([]workflow.Data, error) {
@@ -47,7 +46,6 @@ func RunUnifiedTestFlow(
 		ictx,
 		testClient,
 		orgID,
-		orgSlugOrID,
 		errFactory,
 		logger,
 		localPolicy,
@@ -67,7 +65,6 @@ func testAllDepGraphs(
 	ictx workflow.InvocationContext,
 	testClient testapi.TestClient,
 	orgID string,
-	orgSlugOrID string,
 	errFactory *errors.ErrorFactory,
 	logger *zerolog.Logger,
 	localPolicy *testapi.LocalPolicy,
@@ -95,7 +92,7 @@ func testAllDepGraphs(
 		// Run the test with the depgraph subject
 		legacyFinding, outputData, err := RunTest(
 			ctx, ictx, testClient, subject, projectName, packageManager, depCount,
-			displayTargetFile, orgID, orgSlugOrID, errFactory, logger, localPolicy)
+			displayTargetFile, orgID, errFactory, logger, localPolicy)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/commands/ostest/sbom_reachability_flow.go
+++ b/internal/commands/ostest/sbom_reachability_flow.go
@@ -25,7 +25,6 @@ func RunSbomReachabilityFlow(
 	sourceCodePath string,
 	bsClient bundlestore.Client,
 	orgID string,
-	orgSlugOrID string,
 ) ([]workflow.Data, error) {
 	if sourceCodePath == "" {
 		sourceCodePath = "."
@@ -68,7 +67,7 @@ func RunSbomReachabilityFlow(
 		return nil, fmt.Errorf("failed to create sbom test reachability subject: %w", err)
 	}
 
-	findings, summary, err := RunTest(ctx, ictx, testClient, subject, "", "", int(0), sbomPath, orgID, orgSlugOrID, errFactory, logger, nil)
+	findings, summary, err := RunTest(ctx, ictx, testClient, subject, "", "", int(0), sbomPath, orgID, errFactory, logger, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/commands/ostest/sbom_reachability_flow_test.go
+++ b/internal/commands/ostest/sbom_reachability_flow_test.go
@@ -39,10 +39,10 @@ func Test_RunSbomReachabilityFlow_JSON(t *testing.T) {
 
 	ctx := context.Background()
 	ef := errors.NewErrorFactory(&nopLogger)
-	mockIctx, mockTestClient, mockBsClient, orgID, orgSlug, sbomPath, sourceCodePath := setupTest(ctx, t, ctrl, true)
+	mockIctx, mockTestClient, mockBsClient, orgID, sbomPath, sourceCodePath := setupTest(ctx, t, ctrl, true)
 
 	// This should now succeed with proper finding data
-	result, err := ostest.RunSbomReachabilityFlow(ctx, mockIctx, mockTestClient, ef, &nopLogger, sbomPath, sourceCodePath, mockBsClient, orgID, orgSlug)
+	result, err := ostest.RunSbomReachabilityFlow(ctx, mockIctx, mockTestClient, ef, &nopLogger, sbomPath, sourceCodePath, mockBsClient, orgID)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -64,10 +64,10 @@ func Test_RunSbomReachabilityFlow_HumanReadable(t *testing.T) {
 
 	ctx := context.Background()
 	ef := errors.NewErrorFactory(&nopLogger)
-	mockIctx, mockTestClient, mockBsClient, orgID, orgSlug, sbomPath, sourceCodePath := setupTest(ctx, t, ctrl, false)
+	mockIctx, mockTestClient, mockBsClient, orgID, sbomPath, sourceCodePath := setupTest(ctx, t, ctrl, false)
 
 	// This should now succeed with proper finding data
-	result, err := ostest.RunSbomReachabilityFlow(ctx, mockIctx, mockTestClient, ef, &nopLogger, sbomPath, sourceCodePath, mockBsClient, orgID, orgSlug)
+	result, err := ostest.RunSbomReachabilityFlow(ctx, mockIctx, mockTestClient, ef, &nopLogger, sbomPath, sourceCodePath, mockBsClient, orgID)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -84,7 +84,6 @@ func setupTest(ctx context.Context, t *testing.T, ctrl *gomock.Controller, jsonO
 	workflow.InvocationContext,
 	testapi.TestClient,
 	bundlestore.Client,
-	string,
 	string,
 	string,
 	string,
@@ -222,5 +221,5 @@ func setupTest(ctx context.Context, t *testing.T, ctrl *gomock.Controller, jsonO
 	mockIctx.EXPECT().GetEnhancedLogger().Return(&nopLogger).AnyTimes()
 	mockIctx.EXPECT().GetRuntimeInfo().Return(runtimeinfo.New()).AnyTimes()
 
-	return mockIctx, mockTestClient, mockBsClient, orgID, orgSlug, sbomPath, sourceCodePath
+	return mockIctx, mockTestClient, mockBsClient, orgID, sbomPath, sourceCodePath
 }

--- a/internal/legacy/transform/transform.go
+++ b/internal/legacy/transform/transform.go
@@ -28,7 +28,7 @@ type SnykSchemaToLegacyParams struct {
 	OrgSlugOrID       string
 	ProjectName       string
 	PackageManager    string
-	CurrentDir        string
+	TargetDir         string
 	UniqueCount       int32
 	DepCount          int
 	DisplayTargetFile string
@@ -398,7 +398,7 @@ func ConvertSnykSchemaFindingsToLegacy(params *SnykSchemaToLegacyParams) (*defin
 	res := definitions.LegacyVulnerabilityResponse{
 		Org:               params.OrgSlugOrID,
 		ProjectName:       params.ProjectName,
-		Path:              params.CurrentDir,
+		Path:              params.TargetDir,
 		PackageManager:    params.PackageManager,
 		DisplayTargetFile: params.DisplayTargetFile,
 		UniqueCount:       params.UniqueCount,

--- a/internal/presenters/funcs.go
+++ b/internal/presenters/funcs.go
@@ -361,6 +361,7 @@ func getDefaultTemplateFuncMap(config configuration.Configuration, ri runtimeinf
 	defaultMap["getFindingId"] = getFindingID
 	defaultMap["hasPrefix"] = strings.HasPrefix
 	defaultMap["isLicenseFinding"] = isLicenseFinding
+	defaultMap["constructDisplayPath"] = constructDisplayPath(config)
 
 	return defaultMap
 }
@@ -432,4 +433,15 @@ func formatDatetime(input, inputFormat, outputFormat string) string {
 	}
 
 	return datetime.Format(outputFormat)
+}
+
+// constructDisplayPath constructs the display path from the summary path and display target file.
+func constructDisplayPath(config configuration.Configuration) func(displayTargetFile string) string {
+	return func(displayTargetFile string) string {
+		summaryPath := config.GetString(configuration.INPUT_DIRECTORY)
+		if displayTargetFile == "" {
+			return summaryPath
+		}
+		return fmt.Sprintf("%s (%s)", summaryPath, displayTargetFile)
+	}
 }

--- a/internal/presenters/templates/unified_finding.tmpl
+++ b/internal/presenters/templates/unified_finding.tmpl
@@ -66,15 +66,16 @@
 {{- end}}{{/* end "details" */}}
 
 {{define "header" }}
-{{ print "Testing " .Summary.Path  " ..." | bold }}
+{{ $displayPath := constructDisplayPath .DisplayTargetFile -}}
+{{ print "Testing " $displayPath " ..." | bold }}
 {{end }}
 
 {{- define "summary"}}{{ "Test Summary" | bold }}
 
   Organization:      {{ getValueFromConfig "internal_org_slug" }}
   Test type:         {{ if eq .Summary.Type "sast" }}Static code analysis{{else}}{{ .Summary.Type }}{{ end}}
-  Project path:      {{ .Summary.Path }}
-
+  Project path:      {{ getValueFromConfig "targetDirectory" }}
+  
   {{- $total := 0 }}{{- $open := 0 }}{{- $ignored := 0 }}
   {{- range $res := .Summary.Results }}
       {{- $total = add $total $res.Total }}


### PR DESCRIPTION
### What this does
Shows target directory and file as "Testing <target dir> (<targe…t file>) ...", and simplifies the JSON output's "org" code.

  - the "Testing ..." line now shows as "Testing <target dir> (target file) ...", which helps distinguish the project in cases like --all-projects.
  - "path" in both human-readable and JSON output is now the Target Directory instead of cwd
  - org and target directory are both obtainable from Configuration, so orgSlug is no longer passed around