### PR TITLE
feat: handle evidence paths for both text and JSON output

### DIFF
--- a/internal/commands/ostest/test_execution_test.go
+++ b/internal/commands/ostest/test_execution_test.go
@@ -1,176 +1,43 @@
 package ostest_test
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
-	"time"
-
-	"github.com/google/uuid"
 
 	"github.com/rs/zerolog"
 	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/content_type"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
-	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/cli-extension-os-flows/internal/commands/ostest"
 )
 
-// mockTestResult is a mock implementation of testapi.TestResult for testing.
-type mockTestResult struct {
-	rawSummary       *testapi.FindingSummary
-	effectiveSummary *testapi.FindingSummary
-}
-
-func (m *mockTestResult) GetRawSummary() *testapi.FindingSummary {
-	return m.rawSummary
-}
-
-func (m *mockTestResult) GetEffectiveSummary() *testapi.FindingSummary {
-	return m.effectiveSummary
-}
-
-// These methods are not used in newSummaryData but are required to satisfy the interface.
-func (m *mockTestResult) GetTestSubject() testapi.TestSubject {
-	return testapi.TestSubject{}
-}
-
-func (m *mockTestResult) Findings(_ context.Context) ([]testapi.FindingData, bool, error) {
-	return nil, false, nil
-}
-
-func (m *mockTestResult) GetExecutionState() testapi.TestExecutionStates {
-	return ""
-}
-
-func (m *mockTestResult) GetTestConfiguration() *testapi.TestConfiguration {
-	return nil
-}
-
-func (m *mockTestResult) GetSubjectLocators() *[]testapi.TestSubjectLocator {
-	return nil
-}
-
-func (m *mockTestResult) GetPassFail() *testapi.PassFail {
-	return nil
-}
-
-func (m *mockTestResult) GetOutcomeReason() *testapi.TestOutcomeReason {
-	return nil
-}
-
-func (m *mockTestResult) GetErrors() *[]testapi.IoSnykApiCommonError {
-	return nil
-}
-
-func (m *mockTestResult) GetWarnings() *[]testapi.IoSnykApiCommonError {
-	return nil
-}
-
-func (m *mockTestResult) GetCreatedAt() *time.Time {
-	return nil
-}
-
-func (m *mockTestResult) GetBreachedPolicies() *testapi.PolicyRefSet {
-	return nil
-}
-
-func (m *mockTestResult) GetTestID() *uuid.UUID {
-	return nil
-}
-
-func (m *mockTestResult) GetID() string {
-	return ""
-}
-
-func Test_NewSummaryData(t *testing.T) {
+func Test_NewSummaryDataFromFindings(t *testing.T) {
 	logger := zerolog.Nop()
 	path := "/test/path"
 
-	t.Run("no findings creates empty summary data, exit code 0", func(t *testing.T) {
-		testResult := &mockTestResult{
-			rawSummary:       &testapi.FindingSummary{Count: 0},
-			effectiveSummary: &testapi.FindingSummary{Count: 0},
-		}
-
-		summary, data, err := ostest.NewSummaryData(testResult, &logger, path)
+	t.Run("no findings returns an empty summary", func(t *testing.T) {
+		summary, data, err := ostest.NewSummaryDataFromFindings([]testapi.FindingData{}, &logger, path)
 		assert.NoError(t, err)
-		assert.Equal(t,
-			workflow.NewData(
-				data.GetIdentifier(),
-				content_type.TEST_SUMMARY,
-				[]byte(`{"results":null,"severity_order_asc":["low","medium","high","critical"],"type":"open-source","artifacts":0,"path":"/test/path"}`),
-			),
-			data,
-		)
-		assert.Equal(t,
-			&json_schemas.TestSummary{
-				Results:          nil,
-				SeverityOrderAsc: []string{"low", "medium", "high", "critical"},
-				Type:             "open-source",
-				Artifacts:        0,
-				Path:             "/test/path",
-			},
-			summary,
-		)
+		assert.NotNil(t, summary)
+		assert.NotNil(t, data)
+		assert.Empty(t, summary.Results)
 	})
 
-	t.Run("no open or total findings should not create summary data", func(t *testing.T) {
-		testResult := &mockTestResult{
-			rawSummary: &testapi.FindingSummary{
-				Count: 0,
-				CountBy: &map[string]map[string]uint32{
-					"severity": {"high": 0},
-				},
-			},
-			effectiveSummary: &testapi.FindingSummary{
-				Count: 0,
-				CountBy: &map[string]map[string]uint32{
-					"severity": {"high": 0},
+	t.Run("one critical finding should create summary data", func(t *testing.T) {
+		findings := []testapi.FindingData{
+			{
+				Attributes: &testapi.FindingAttributes{
+					Rating: testapi.Rating{
+						Severity: testapi.SeverityCritical,
+					},
 				},
 			},
 		}
 
-		summaryStruct, data, err := ostest.NewSummaryData(testResult, &logger, path)
-		assert.NoError(t, err)
-		assert.Equal(t,
-			workflow.NewData(
-				data.GetIdentifier(),
-				content_type.TEST_SUMMARY,
-				[]byte(`{"results":null,"severity_order_asc":["low","medium","high","critical"],"type":"open-source","artifacts":0,"path":"/test/path"}`),
-			),
-			data)
-		assert.Equal(t,
-			&json_schemas.TestSummary{
-				Results:          nil,
-				SeverityOrderAsc: []string{"low", "medium", "high", "critical"},
-				Type:             "open-source",
-				Artifacts:        0,
-				Path:             "/test/path",
-			},
-			summaryStruct)
-	})
-
-	t.Run("one critical finding should create summary data, implying exit code 1", func(t *testing.T) {
-		testResult := &mockTestResult{
-			rawSummary: &testapi.FindingSummary{
-				Count: 1,
-				CountBy: &map[string]map[string]uint32{
-					"severity": {"critical": 1},
-				},
-			},
-			effectiveSummary: &testapi.FindingSummary{
-				Count: 1,
-				CountBy: &map[string]map[string]uint32{
-					"severity": {"critical": 1},
-				},
-			},
-		}
-
-		summaryStruct, data, err := ostest.NewSummaryData(testResult, &logger, path)
+		summaryStruct, data, err := ostest.NewSummaryDataFromFindings(findings, &logger, path)
 		require.NoError(t, err)
 		require.NotNil(t, data)
 		require.NotNil(t, summaryStruct)
@@ -198,28 +65,32 @@ func Test_NewSummaryData(t *testing.T) {
 		assert.Equal(t, "critical", summaryStruct.Results[0].Severity)
 	})
 
-	t.Run("multiple findings with ignored", func(t *testing.T) {
-		testResult := &mockTestResult{
-			rawSummary: &testapi.FindingSummary{
-				Count: 3,
-				CountBy: &map[string]map[string]uint32{
-					"severity": {
-						"high":   2,
-						"medium": 1,
+	t.Run("multiple findings are all considered open", func(t *testing.T) {
+		findings := []testapi.FindingData{
+			{
+				Attributes: &testapi.FindingAttributes{
+					Rating: testapi.Rating{
+						Severity: testapi.SeverityHigh,
 					},
 				},
 			},
-			effectiveSummary: &testapi.FindingSummary{
-				Count: 1,
-				CountBy: &map[string]map[string]uint32{
-					"severity": {
-						"high": 1,
+			{
+				Attributes: &testapi.FindingAttributes{
+					Rating: testapi.Rating{
+						Severity: testapi.SeverityHigh,
+					},
+				},
+			},
+			{
+				Attributes: &testapi.FindingAttributes{
+					Rating: testapi.Rating{
+						Severity: testapi.SeverityMedium,
 					},
 				},
 			},
 		}
 
-		summaryStruct, data, err := ostest.NewSummaryData(testResult, &logger, path)
+		summaryStruct, data, err := ostest.NewSummaryDataFromFindings(findings, &logger, path)
 		require.NoError(t, err)
 		require.NotNil(t, data)
 		require.NotNil(t, summaryStruct)
@@ -237,26 +108,21 @@ func Test_NewSummaryData(t *testing.T) {
 		// Results are sorted by severity descending
 		assert.Equal(t, "high", summary.Results[0].Severity)
 		assert.Equal(t, 2, summary.Results[0].Total)
-		assert.Equal(t, 1, summary.Results[0].Open)
-		assert.Equal(t, 1, summary.Results[0].Ignored)
+		assert.Equal(t, 2, summary.Results[0].Open)
+		assert.Equal(t, 0, summary.Results[0].Ignored)
 
 		assert.Equal(t, "medium", summary.Results[1].Severity)
 		assert.Equal(t, 1, summary.Results[1].Total)
-		assert.Equal(t, 0, summary.Results[1].Open)
-		assert.Equal(t, 1, summary.Results[1].Ignored)
+		assert.Equal(t, 1, summary.Results[1].Open)
+		assert.Equal(t, 0, summary.Results[1].Ignored)
 	})
 
-	t.Run("summary is nil", func(t *testing.T) {
-		testResult := &mockTestResult{
-			rawSummary:       nil,
-			effectiveSummary: nil,
-		}
-
-		summary, data, err := ostest.NewSummaryData(testResult, &logger, path)
-		assert.Nil(t, data)
-		assert.Nil(t, summary)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "test result missing summary information")
+	t.Run("nil findings slice returns an empty summary", func(t *testing.T) {
+		summary, data, err := ostest.NewSummaryDataFromFindings(nil, &logger, path)
+		assert.NoError(t, err)
+		assert.NotNil(t, summary)
+		assert.NotNil(t, data)
+		assert.Empty(t, summary.Results)
 	})
 
 	t.Run("newWorkflowData creates correct content types", func(t *testing.T) {

--- a/internal/outputworkflow/findings_model_tools.go
+++ b/internal/outputworkflow/findings_model_tools.go
@@ -74,13 +74,14 @@ func getUnifiedProjectResults(input []workflow.Data, debugLogger *zerolog.Logger
 			}
 
 			projectResult := &presenters.UnifiedProjectResult{
-				Findings:          *currentFindingsData,
-				Summary:           summaryPayload.Summary,
-				DependencyCount:   summaryPayload.DependencyCount,
-				PackageManager:    summaryPayload.PackageManager,
-				ProjectName:       summaryPayload.ProjectName,
-				DisplayTargetFile: summaryPayload.DisplayTargetFile,
-				UniqueCount:       int(summaryPayload.UniqueCount),
+				Findings:             *currentFindingsData,
+				Summary:              summaryPayload.Summary,
+				DependencyCount:      summaryPayload.DependencyCount,
+				PackageManager:       summaryPayload.PackageManager,
+				ProjectName:          summaryPayload.ProjectName,
+				DisplayTargetFile:    summaryPayload.DisplayTargetFile,
+				UniqueCount:          int(summaryPayload.UniqueCount),
+				VulnerablePathsCount: summaryPayload.VulnerablePathsCount,
 			}
 			projectResults = append(projectResults, projectResult)
 

--- a/internal/presenters/presenter_unified_finding.go
+++ b/internal/presenters/presenter_unified_finding.go
@@ -41,23 +41,25 @@ var DefaultTemplateFiles = []string{
 
 // UnifiedProjectResult holds the findings and summary for a single project from the unified flow.
 type UnifiedProjectResult struct {
-	Findings          []testapi.FindingData
-	Summary           *json_schemas.TestSummary
-	DependencyCount   int
-	PackageManager    string
-	ProjectName       string
-	DisplayTargetFile string
-	UniqueCount       int
+	Findings             []testapi.FindingData
+	Summary              *json_schemas.TestSummary
+	DependencyCount      int
+	PackageManager       string
+	ProjectName          string
+	DisplayTargetFile    string
+	UniqueCount          int
+	VulnerablePathsCount int
 }
 
 // SummaryPayload is a wrapper for the test summary and additional metadata needed for the unified output.
 type SummaryPayload struct {
-	Summary           *json_schemas.TestSummary `json:"summary"`
-	DependencyCount   int                       `json:"dependencyCount"`
-	PackageManager    string                    `json:"packageManager"`
-	ProjectName       string                    `json:"projectName"`
-	DisplayTargetFile string                    `json:"displayTargetFile"`
-	UniqueCount       int32                     `json:"uniqueCount"`
+	Summary              *json_schemas.TestSummary `json:"summary"`
+	DependencyCount      int                       `json:"dependencyCount"`
+	PackageManager       string                    `json:"packageManager"`
+	ProjectName          string                    `json:"projectName"`
+	DisplayTargetFile    string                    `json:"displayTargetFile"`
+	UniqueCount          int32                     `json:"uniqueCount"`
+	VulnerablePathsCount int                       `json:"vulnerablePathsCount"`
 }
 
 // UnifiedFindingPresenter is responsible for rendering unified findings data.

--- a/internal/presenters/templates/unified_finding.tmpl
+++ b/internal/presenters/templates/unified_finding.tmpl
@@ -111,14 +111,16 @@
 {{- range .Results}}
     {{- template "header"  . }}
 
-    {{- $totalIssues := .UniqueCount }}
-    {{- $vulnerablePaths := len .Findings }}
+    {{- $totalIssues := 0 }}
+    {{- range $res := .Summary.Results }}
+        {{- $totalIssues = add $totalIssues $res.Total }}
+    {{- end }}
 
     {{- if gt .DependencyCount 0 -}}
         {{- if eq $totalIssues 0 -}}
             {{- printf "\n✔ Tested %d dependencies for known issues, no vulnerable paths found.\n" .DependencyCount | renderGreen -}}
         {{- else -}}
-            {{- printf "\nTested %d dependencies for known issues, found %d issues, %d vulnerable paths.\n" .DependencyCount $totalIssues $vulnerablePaths -}}
+            {{- printf "\nTested %d dependencies for known issues, found %d issues, %d vulnerable paths.\n" .DependencyCount $totalIssues .VulnerablePathsCount -}}
         {{- end -}}
     {{- end }}
 


### PR DESCRIPTION
  - human-readable output: aggregates by Snyk ID for both the issue list and the Open Issues count.

  - json output: create a distinct vulnerability for each evidence of type dependency_path so that Snyk-to-html can aggregate and count them.

  - json output: "uniqueCount" is the total of unique Snyk IDs seen.

new expectations:
  - "total issues" match between human readable and snyk-to-html output.
  - "uniqueCount" in JSON also matches "total issues" above.
  - "vulnerable dependency paths" in snyk-to-html matches "vulnerable paths" in human-readable output