### PR TITLE
fix(bundlestore): use local target for code upload

### DIFF
--- a/internal/bundlestore/client.go
+++ b/internal/bundlestore/client.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	codeclient "github.com/snyk/code-client-go"
-	codeclientscan "github.com/snyk/code-client-go/scan"
 
 	listsources "github.com/snyk/cli-extension-os-flows/internal/files"
 )
@@ -205,17 +204,12 @@ func (c *HTTPClient) UploadSourceCode(ctx context.Context, sourceCodePath string
 	numThreads := runtime.NumCPU()
 	filesChan, err := listsources.ForPath(sourceCodePath, c.logger, numThreads)
 	if err != nil {
-		c.logger.Error().Err(err).Str("sourceCodePath", sourceCodePath).Msg("failed to list files in directory") //nolint:goconst // repeated sourceCodePath is fine
+		c.logger.Error().Err(err).Str("sourceCodePath", sourceCodePath).Msg("failed to list files in directory")
 		return "", fmt.Errorf("failed to list files in directory")
 	}
 
-	target, err := codeclientscan.NewRepositoryTarget(sourceCodePath)
-	if err != nil {
-		c.logger.Error().Err(err).Str("sourceCodePath", sourceCodePath).Msg("failed to initialize target")
-		return "", fmt.Errorf("failed to initialize target")
-	}
-
 	requestID := uuid.New().String()
+	target := LocalTarget{sourceCodePath}
 	bundle, err := c.codeScanner.Upload(ctx, requestID, target, filesChan, make(map[string]bool))
 	if err != nil {
 		c.logger.Error().Err(err).Str("sourceCodePath", sourceCodePath).Msg("failed to upload source code")

--- a/internal/bundlestore/localtarget.go
+++ b/internal/bundlestore/localtarget.go
@@ -1,0 +1,11 @@
+package bundlestore
+
+// LocalTarget satisfies the scan.Target interface required for uploading source code.
+type LocalTarget struct {
+	path string
+}
+
+// GetPath returns the path of the LocalTarget.
+func (lt LocalTarget) GetPath() string {
+	return lt.path
+}


### PR DESCRIPTION
# What this does?

Creates a `LocalTarget` type to be used for uploading the source code to the bundle store. This replaces the `RepositoryTarget` which required the source code path to be a git repository.