### PR TITLE
feat: [DGP-825] add a "suppress-pending-ignores" flag for localPolicy

### DIFF
--- a/internal/commands/ostest/workflow.go
+++ b/internal/commands/ostest/workflow.go
@@ -176,7 +176,8 @@ func handleDepgraphReachabilityFlow(
 	return RunUnifiedTestFlow(ctx, ictx, testClient, orgUUID.String(), errFactory, logger, localPolicy, &scanID)
 }
 
-// CreateLocalPolicy will create a local policy only if risk score or severity threshold are specified in the config.
+// CreateLocalPolicy will create a local policy only if risk score, severity threshold,
+// or suppress pending ignores are specified in the config.
 func CreateLocalPolicy(config configuration.Configuration, logger *zerolog.Logger) *testapi.LocalPolicy {
 	var riskScoreThreshold *uint16
 	riskScoreThresholdInt := config.GetInt(flags.FlagRiskScoreThreshold)
@@ -197,13 +198,16 @@ func CreateLocalPolicy(config configuration.Configuration, logger *zerolog.Logge
 		severityThreshold = &st
 	}
 
-	if riskScoreThreshold == nil && severityThreshold == nil {
+	suppressPendingIgnores := config.GetBool(flags.FlagSuppressPendingIgnores)
+
+	if riskScoreThreshold == nil && severityThreshold == nil && !suppressPendingIgnores {
 		return nil
 	}
 
 	return &testapi.LocalPolicy{
-		RiskScoreThreshold: riskScoreThreshold,
-		SeverityThreshold:  severityThreshold,
+		RiskScoreThreshold:     riskScoreThreshold,
+		SeverityThreshold:      severityThreshold,
+		SuppressPendingIgnores: suppressPendingIgnores,
 	}
 }
 

--- a/internal/commands/ostest/workflow_test.go
+++ b/internal/commands/ostest/workflow_test.go
@@ -43,6 +43,7 @@ func TestOSWorkflow_CreateLocalPolicy(t *testing.T) {
 	mockConfig := mockInvocationCtx.GetConfiguration()
 	mockConfig.Set(flags.FlagRiskScoreThreshold, 100)
 	mockConfig.Set(flags.FlagSeverityThreshold, "high")
+	mockConfig.Set(flags.FlagSuppressPendingIgnores, true)
 
 	localPolicy := ostest.CreateLocalPolicy(mockConfig, &logger)
 	require.NotNil(t, localPolicy)
@@ -51,6 +52,7 @@ func TestOSWorkflow_CreateLocalPolicy(t *testing.T) {
 	assert.Equal(t, uint16(100), *localPolicy.RiskScoreThreshold)
 	require.NotNil(t, localPolicy.SeverityThreshold)
 	assert.Equal(t, "high", string(*localPolicy.SeverityThreshold))
+	assert.True(t, localPolicy.SuppressPendingIgnores)
 }
 
 func TestOSWorkflow_CreateLocalPolicy_NoValues(t *testing.T) {

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -5,11 +5,14 @@ import "github.com/spf13/pflag"
 
 // Defines the command-line flags used in the OS-Flows CLI extension.
 const (
+	// Local policy.
+	FlagRiskScoreThreshold     = "risk-score-threshold"
+	FlagSeverityThreshold      = "severity-threshold"
+	FlagSuppressPendingIgnores = "suppress-pending-ignores"
+
 	// Open Source.
-	FlagFile               = "file"
-	FlagProjectName        = "project-name"
-	FlagRiskScoreThreshold = "risk-score-threshold"
-	FlagSeverityThreshold  = "severity-threshold"
+	FlagFile        = "file"
+	FlagProjectName = "project-name"
 
 	// SBOM reachability.
 	FlagReachability = "reachability"
@@ -70,12 +73,14 @@ const (
 func OSTestFlagSet() *pflag.FlagSet {
 	flagSet := pflag.NewFlagSet("snyk-cli-extension-os-flows", pflag.ExitOnError)
 
+	// Local policy
+	flagSet.Int(FlagRiskScoreThreshold, -1, "Include findings at or over this risk score threshold.")
+	flagSet.String(FlagSeverityThreshold, "", "Report only findings at the specified level or higher.")
+	flagSet.Bool(FlagSuppressPendingIgnores, false, "Suppress ignores pending approval, so that they do not fail the test.")
+
 	// Open Source
 	flagSet.String(FlagFile, "", "Specify a package file.")
 	flagSet.String(FlagProjectName, "", "Specify a name for the project.")
-
-	flagSet.Int(FlagRiskScoreThreshold, -1, "Include findings at or over this risk score threshold.")
-	flagSet.String(FlagSeverityThreshold, "", "Report only findings at the specified level or higher.")
 
 	// Reachability
 	flagSet.Bool(FlagReachability, false, "Run reachability analysis on source code.")


### PR DESCRIPTION
This completes inputs to the test-api-shim's local policy, which = {severity threshold, risk score threshold, suppress pending ignores}.

  - note: it is not implemented at the CLI, but passed along for use by a future enricher. It would mark pending ignores as enforced or not.