### PR TITLE
Fix/upload revision validate files

### DIFF
--- a/internal/fileupload/errors.go
+++ b/internal/fileupload/errors.go
@@ -20,8 +20,8 @@ type FileCountLimitError = uploadrevision.FileCountLimitError
 // FileAccessError indicates a file access permission issue.
 type FileAccessError = uploadrevision.FileAccessError
 
-// DirectoryError indicates an issue with directory operations.
-type DirectoryError = uploadrevision.DirectoryError
+// SpecialFileError indicates a path points to a special file (device, pipe, socket, etc.) instead of a regular file.
+type SpecialFileError = uploadrevision.SpecialFileError
 
 // HTTPError indicates an HTTP request/response error.
 type HTTPError = uploadrevision.HTTPError

--- a/internal/fileupload/uploadrevision/client.go
+++ b/internal/fileupload/uploadrevision/client.go
@@ -195,8 +195,8 @@ func validateFiles(files []UploadFile) error {
 			return NewFileAccessError(file.Path, err)
 		}
 
-		if fileInfo.IsDir() {
-			return NewDirectoryError(file.Path)
+		if !fileInfo.Mode().IsRegular() {
+			return NewSpecialFileError(file.Path, fileInfo.Mode())
 		}
 
 		if fileInfo.Size() > fileSizeLimit {

--- a/internal/fileupload/uploadrevision/errors.go
+++ b/internal/fileupload/uploadrevision/errors.go
@@ -3,6 +3,7 @@ package uploadrevision
 import (
 	"errors"
 	"fmt"
+	"os"
 )
 
 // Sentinel errors for common conditions.
@@ -47,15 +48,6 @@ func (e *FileAccessError) Unwrap() error {
 	return e.Err
 }
 
-// DirectoryError indicates a path points to a directory instead of a file.
-type DirectoryError struct {
-	Path string
-}
-
-func (e *DirectoryError) Error() string {
-	return fmt.Sprintf("path %s is a directory, not a file", e.Path)
-}
-
 // HTTPError represents an HTTP error response.
 type HTTPError struct {
 	StatusCode int
@@ -80,6 +72,16 @@ func (e *MultipartError) Error() string {
 
 func (e *MultipartError) Unwrap() error {
 	return e.Err
+}
+
+// SpecialFileError indicates a path points to a special file (device, pipe, socket, etc.) instead of a regular file.
+type SpecialFileError struct {
+	Path string
+	Mode os.FileMode
+}
+
+func (e *SpecialFileError) Error() string {
+	return fmt.Sprintf("path %s is not a regular file (mode: %s)", e.Path, e.Mode)
 }
 
 // NewFileSizeLimitError creates a new FileSizeLimitError with the given parameters.
@@ -107,13 +109,6 @@ func NewFileAccessError(filePath string, err error) *FileAccessError {
 	}
 }
 
-// NewDirectoryError creates a new DirectoryError with the given path.
-func NewDirectoryError(path string) *DirectoryError {
-	return &DirectoryError{
-		Path: path,
-	}
-}
-
 // NewHTTPError creates a new HTTPError with the given parameters.
 func NewHTTPError(statusCode int, status, operation string, body []byte) *HTTPError {
 	return &HTTPError{
@@ -129,5 +124,13 @@ func NewMultipartError(filePath string, err error) *MultipartError {
 	return &MultipartError{
 		FilePath: filePath,
 		Err:      err,
+	}
+}
+
+// NewSpecialFileError creates a new SpecialFileError with the given path and mode.
+func NewSpecialFileError(path string, mode os.FileMode) *SpecialFileError {
+	return &SpecialFileError{
+		Path: path,
+		Mode: mode,
 	}
 }

--- a/internal/fileupload/uploadrevision/fake_client.go
+++ b/internal/fileupload/uploadrevision/fake_client.go
@@ -81,8 +81,8 @@ func (f *FakeSealableClient) UploadFiles(_ context.Context, orgID OrgID, revisio
 			return NewFileAccessError(file.Path, err)
 		}
 
-		if fileInfo.IsDir() {
-			return NewDirectoryError(file.Path)
+		if !fileInfo.Mode().IsRegular() {
+			return NewSpecialFileError(file.Path, fileInfo.Mode())
 		}
 
 		if fileInfo.Size() > f.cfg.FileSizeLimit {


### PR DESCRIPTION
# What this does?

* Updates the `uploadrevision` file validation so that only "regular" files are allowed
* Removes the `DirectoryError` in favour of a more generic `SpecialFileError`