### PR TITLE
fix: add back Total issues: 0 line when no other issues found

### DIFF
--- a/internal/presenters/presenter_unified_finding_test.go
+++ b/internal/presenters/presenter_unified_finding_test.go
@@ -331,6 +331,36 @@ func TestUnifiedFindingPresenter_CliOutput(t *testing.T) {
 		assert.Contains(t, out, "Total license issues: 1")
 		assert.NotContains(t, out, "Total security issues")
 	})
+
+	// summary shows Total issues: 0 when no findings of any kind are present
+	t.Run("summary shows Total issues: 0 when no issues", func(t *testing.T) {
+		config := configuration.New()
+		buffer := &bytes.Buffer{}
+
+		projectResult := &presenters.UnifiedProjectResult{
+			Findings: []testapi.FindingData{},
+			Summary: &json_schemas.TestSummary{
+				Type:             "open-source",
+				Path:             "test/path",
+				SeverityOrderAsc: []string{"low", "medium", "high", "critical"},
+				Results:          []json_schemas.TestSummaryResult{},
+			},
+		}
+
+		presenter := presenters.NewUnifiedFindingsRenderer(
+			[]*presenters.UnifiedProjectResult{projectResult},
+			config,
+			buffer,
+		)
+
+		err := presenter.RenderTemplate(presenters.DefaultTemplateFiles, presenters.DefaultMimeType)
+		assert.NoError(t, err)
+
+		out := buffer.String()
+		assert.Contains(t, out, "Total issues: 0")
+		assert.NotContains(t, out, "Total security issues")
+		assert.NotContains(t, out, "Total license issues")
+	})
 }
 
 // TestUnifiedFindingPresenter_PendingIgnore_ShownAsOpenWithLabelAndBang verifies that pending ignores are shown as open with a label and ! marker.

--- a/internal/presenters/templates/unified_finding.tmpl
+++ b/internal/presenters/templates/unified_finding.tmpl
@@ -96,6 +96,11 @@
   {{- $vulnResults := getSummaryResultsByIssueType "vulnerability" .Findings .Summary.SeverityOrderAsc }}
   {{- $licenseResults := getSummaryResultsByIssueType "license" .Findings .Summary.SeverityOrderAsc }}
 
+  {{- if and (eq (len $vulnResults) 0) (eq (len $licenseResults) 0) }}
+  {{- "\n" }}
+  Total issues: 0
+  {{- end }}
+
   {{- if gt (len $vulnResults) 0 }}
 
   Total security issues: {{ getIssueCountsTotal $vulnResults }}


### PR DESCRIPTION
  - Security and License groups show only if non-empty, so we need this line for 0 findings