### PR TITLE
fix(fileupload): add IsFedRamp field to high level client config

### DIFF
--- a/internal/fileupload/client.go
+++ b/internal/fileupload/client.go
@@ -18,8 +18,9 @@ import (
 
 // Config contains configuration for the file upload client.
 type Config struct {
-	BaseURL string
-	OrgID   OrgID
+	BaseURL   string
+	OrgID     OrgID
+	IsFedRamp bool
 }
 
 // HTTPClient provides high-level file upload functionality.
@@ -59,7 +60,8 @@ func NewClient(httpClient *http.Client, cfg Config, opts ...Option) *HTTPClient 
 
 	if client.filtersClient == nil {
 		client.filtersClient = filters.NewDeeproxyClient(filters.Config{
-			BaseURL: cfg.BaseURL,
+			BaseURL:   cfg.BaseURL,
+			IsFedRamp: cfg.IsFedRamp,
 		}, filters.WithHTTPClient(httpClient))
 	}
 

--- a/internal/fileupload/uploadrevision/client.go
+++ b/internal/fileupload/uploadrevision/client.go
@@ -269,7 +269,7 @@ func handleUnexpectedStatusCodes(body io.ReadCloser, statusCode int, status, ope
 			for i := range snykErrorList {
 				errsToJoin = append(errsToJoin, snykErrorList[i])
 			}
-			return fmt.Errorf("API error during %s: %w", operation, errors.Join(errsToJoin...))
+			return fmt.Errorf("api error during %s: %w", operation, errors.Join(errsToJoin...))
 		}
 	}
 


### PR DESCRIPTION
# What this does?

Adds a `IsFedRamp` field to the high level file upload client which will be passed to the low level filters client to determine the api url to be used.