### PR TITLE
feat: add missing fake clients

### DIFF
--- a/internal/bundlestore/fake_client.go
+++ b/internal/bundlestore/fake_client.go
@@ -1,0 +1,60 @@
+package bundlestore
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/google/uuid"
+)
+
+type FakeClient struct {
+	uploads map[string]string // path -> bundle hash
+	err     error
+}
+
+var _ Client = (*FakeClient)(nil)
+
+// NewFakeClient creates a new fake bundlestore client.
+func NewFakeClient() *FakeClient {
+	return &FakeClient{
+		uploads: make(map[string]string),
+	}
+}
+
+// WithError configures the fake to return an error.
+func (f *FakeClient) WithError(err error) *FakeClient {
+	f.err = err
+	return f
+}
+
+func (f *FakeClient) uploadPath(_ context.Context, path string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		return "", fmt.Errorf("path does not exist: %s", path)
+	}
+
+	bundleHash := uuid.NewString()
+	f.uploads[path] = bundleHash
+
+	return bundleHash, nil
+}
+
+func (f *FakeClient) UploadSourceCode(ctx context.Context, sourceCodePath string) (string, error) {
+	return f.uploadPath(ctx, sourceCodePath)
+}
+
+func (f *FakeClient) UploadSBOM(ctx context.Context, sbomPath string) (string, error) {
+	return f.uploadPath(ctx, sbomPath)
+}
+
+func (f *FakeClient) GetUploadedBundleHash(path string) string {
+	return f.uploads[path]
+}
+
+func (f *FakeClient) GetUploadCount() int {
+	return len(f.uploads)
+}

--- a/internal/fileupload/client.go
+++ b/internal/fileupload/client.go
@@ -38,6 +38,8 @@ type Client interface {
 	CreateRevisionFromFile(ctx context.Context, filePath string, opts UploadOptions) (RevisionID, error)
 }
 
+var _ Client = (*HTTPClient)(nil)
+
 // NewClient creates a new high-level file upload client.
 func NewClient(httpClient *http.Client, cfg Config, opts ...Option) *HTTPClient {
 	client := &HTTPClient{

--- a/internal/fileupload/fake_client.go
+++ b/internal/fileupload/fake_client.go
@@ -1,0 +1,80 @@
+package fileupload
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/google/uuid"
+
+	"github.com/snyk/cli-extension-os-flows/internal/fileupload/uploadrevision"
+)
+
+type FakeClient struct {
+	revisions map[RevisionID][]string
+	err       error
+}
+
+var _ Client = (*FakeClient)(nil)
+
+// NewFakeClient creates a new fake client.
+func NewFakeClient() *FakeClient {
+	return &FakeClient{
+		revisions: make(map[RevisionID][]string),
+	}
+}
+
+// WithError configures the fake to return an error.
+func (f *FakeClient) WithError(err error) *FakeClient {
+	f.err = err
+	return f
+}
+
+func (f *FakeClient) CreateRevisionFromDir(ctx context.Context, dirPath string, opts UploadOptions) (RevisionID, error) {
+	if f.err != nil {
+		return uuid.Nil, f.err
+	}
+
+	info, err := os.Stat(dirPath)
+	if err != nil {
+		return uuid.Nil, uploadrevision.NewFileAccessError(dirPath, err)
+	}
+
+	if !info.IsDir() {
+		return uuid.Nil, fmt.Errorf("the provided path is not a directory: %s", dirPath)
+	}
+
+	return f.CreateRevisionFromPaths(ctx, []string{dirPath}, opts)
+}
+
+func (f *FakeClient) CreateRevisionFromFile(ctx context.Context, filePath string, opts UploadOptions) (RevisionID, error) {
+	if f.err != nil {
+		return uuid.Nil, f.err
+	}
+
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return uuid.Nil, uploadrevision.NewFileAccessError(filePath, err)
+	}
+
+	if !info.Mode().IsRegular() {
+		return uuid.Nil, fmt.Errorf("the provided path is not a regular file: %s", filePath)
+	}
+
+	return f.CreateRevisionFromPaths(ctx, []string{filePath}, opts)
+}
+
+func (f *FakeClient) CreateRevisionFromPaths(ctx context.Context, paths []string, opts UploadOptions) (RevisionID, error) {
+	if f.err != nil {
+		return uuid.Nil, f.err
+	}
+
+	revID := uuid.New()
+	f.revisions[revID] = append([]string(nil), paths...)
+
+	return revID, nil
+}
+
+func (f *FakeClient) GetRevisionPaths(revID RevisionID) []string {
+	return f.revisions[revID]
+}

--- a/internal/fileupload/filters/client.go
+++ b/internal/fileupload/filters/client.go
@@ -32,6 +32,8 @@ type Config struct {
 	IsFedRamp bool
 }
 
+var _ Client = (*DeeproxyClient)(nil)
+
 // NewDeeproxyClient creates a new DeeproxyClient with the given configuration and options.
 func NewDeeproxyClient(cfg Config, opts ...Opt) *DeeproxyClient {
 	c := &DeeproxyClient{

--- a/internal/fileupload/filters/fake_client.go
+++ b/internal/fileupload/filters/fake_client.go
@@ -10,6 +10,8 @@ type FakeClient struct {
 	getFilters func(ctx context.Context, orgID uuid.UUID) (AllowList, error)
 }
 
+var _ Client = (*FakeClient)(nil)
+
 func NewFakeClient(allowList AllowList, err error) *FakeClient {
 	return &FakeClient{
 		getFilters: func(ctx context.Context, orgID uuid.UUID) (AllowList, error) {

--- a/internal/fileupload/uploadrevision/fake_client.go
+++ b/internal/fileupload/uploadrevision/fake_client.go
@@ -31,6 +31,8 @@ type FakeClientConfig struct {
 	Limits
 }
 
+var _ SealableClient = (*FakeSealableClient)(nil)
+
 // NewFakeSealableClient creates a new instance of the fake client.
 func NewFakeSealableClient(cfg FakeClientConfig) *FakeSealableClient {
 	return &FakeSealableClient{


### PR DESCRIPTION
# What this does?

Adds a fake `fileupload` and a fake `bundlestore` client, to be used in tests.