### PR TITLE
DGP-862 - return error for incomplete findings

### DIFF
--- a/internal/commands/ostest/test_execution.go
+++ b/internal/commands/ostest/test_execution.go
@@ -152,6 +152,15 @@ func executeTest(
 		if !complete && len(findingsData) > 0 {
 			logger.Warn().Int(LogFieldCount, len(findingsData)).Msg("Partial findings retrieved as an error occurred")
 		}
+		return finalResult, findingsData, errFactory.NewTestExecutionError(
+			fmt.Sprintf("test completed but findings could not be retrieved: %v", err),
+		)
+	}
+	if !complete {
+		if len(findingsData) > 0 {
+			logger.Warn().Int(LogFieldCount, len(findingsData)).Msg("Partial findings retrieved; findings retrieval incomplete")
+		}
+		return finalResult, findingsData, errFactory.NewTestExecutionError("test completed but findings could not be retrieved")
 	}
 	return finalResult, findingsData, nil
 }


### PR DESCRIPTION
  - Handles the test passing but the Findings endpoint returning incomplete or errored findings. The previous intent was to return partial findings as a non-error for presentation but it's clearer to fail the test to avoid assumptions of success.

  - The debug logs will now show, e.g., "Test execution failed: test completed but findings could not be retrieved: <error>"

  - Adds unit tests for both the error and incomplete cases.