### PR TITLE
feat: add settings client [OSF-91]

### DIFF
--- a/internal/reachability/client_test.go
+++ b/internal/reachability/client_test.go
@@ -33,7 +33,7 @@ type TestServerConfig struct {
 	ResponseBodies     []string // Cycles through these responses for polling scenarios
 }
 
-func setupTest(t *testing.T, serverConfig *TestServerConfig, clientConfig ...reachability.Config) (rc *reachability.SCAEngineClient, cc *int32) {
+func setupTest(t *testing.T, serverConfig *TestServerConfig, clientConfig ...reachability.Config) (rc *reachability.HTTPClient, cc *int32) {
 	t.Helper()
 
 	var callCount int32

--- a/internal/settings/client.go
+++ b/internal/settings/client.go
@@ -1,0 +1,88 @@
+package settings
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+)
+
+// Config contains configuration for the reachability settings client.
+type Config struct {
+	BaseURL string
+}
+
+// HTTPClient provides functionality for interacting with the settings API.
+type HTTPClient struct {
+	httpClient *http.Client
+	cfg        Config
+}
+
+// Client defines the interface for accessing reachability settings.
+type Client interface {
+	IsReachabilityEnabled(ctx context.Context, orgID OrgID) (bool, error)
+}
+
+var _ Client = (*HTTPClient)(nil)
+
+const apiVersion = "2024-10-15"
+
+// NewClient creates a new RegistryClient with the provided HTTP client and configuration.
+func NewClient(httpClient *http.Client, cfg Config) *HTTPClient {
+	return &HTTPClient{httpClient, cfg}
+}
+
+// IsReachabilityEnabled checks if reachability analysis is enabled for the given organization.
+func (rc *HTTPClient) IsReachabilityEnabled(ctx context.Context, orgID OrgID) (bool, error) {
+	if orgID == uuid.Nil {
+		return false, ErrEmptyOrgID
+	}
+
+	url := fmt.Sprintf("%s/rest/orgs/%s/settings/opensource?version=%s", rc.cfg.BaseURL, orgID, apiVersion)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return false, fmt.Errorf("failed to create reachability settings request: %w", err)
+	}
+
+	res, err := rc.httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("error making reachability setting request: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return false, handleUnexpectedStatusCodes(res.Body, res.StatusCode, res.Status, "reachability settings")
+	}
+
+	var respBody ResponseBody
+	if err := json.NewDecoder(res.Body).Decode(&respBody); err != nil {
+		return false, fmt.Errorf("failed to decode reachability settings response body: %w", err)
+	}
+
+	return respBody.Data.Attributes.Reachability.Enabled, nil
+}
+
+func handleUnexpectedStatusCodes(body io.ReadCloser, statusCode int, status, operation string) error {
+	bts, err := io.ReadAll(body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if len(bts) > 0 {
+		snykErrorList, parseErr := snyk_errors.FromJSONAPIErrorBytes(bts)
+		if parseErr == nil && len(snykErrorList) > 0 && snykErrorList[0].Title != "" {
+			errsToJoin := []error{}
+			for i := range snykErrorList {
+				errsToJoin = append(errsToJoin, snykErrorList[i])
+			}
+			return fmt.Errorf("api error during %s: %w", operation, errors.Join(errsToJoin...))
+		}
+	}
+
+	return NewHTTPError(statusCode, status, operation, bts)
+}

--- a/internal/settings/client_test.go
+++ b/internal/settings/client_test.go
@@ -1,0 +1,60 @@
+package settings_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-os-flows/internal/settings"
+)
+
+func Test_IsReachabilityEnabled(t *testing.T) {
+	orgID := uuid.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, fmt.Sprintf("/rest/orgs/%s/settings/opensource", orgID), r.URL.Path)
+
+		w.Write([]byte(
+			`{
+			"jsonapi": {
+				"version": "1.0"
+			},
+			"data": {
+				"type": "opensource_settings",
+				"attributes": {
+					"reachability": {
+						"enabled": true
+					}
+				}
+			}
+		}`))
+	}))
+	defer srv.Close()
+	rsc := settings.NewClient(srv.Client(), settings.Config{BaseURL: srv.URL})
+
+	isEnabled, err := rsc.IsReachabilityEnabled(t.Context(), orgID)
+	require.NoError(t, err)
+
+	assert.Equal(t, true, isEnabled)
+}
+
+func Test_IsReachabilityEnabled_ServerError(t *testing.T) {
+	orgID := uuid.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, fmt.Sprintf("/rest/orgs/%s/settings/opensource", orgID), r.URL.Path)
+
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	rsc := settings.NewClient(srv.Client(), settings.Config{BaseURL: srv.URL})
+
+	_, err := rsc.IsReachabilityEnabled(t.Context(), orgID)
+
+	assert.ErrorContains(t, err, "unsuccessful request to reachability settings")
+}

--- a/internal/settings/errors.go
+++ b/internal/settings/errors.go
@@ -1,0 +1,33 @@
+package settings
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors for common conditions.
+var (
+	ErrEmptyOrgID = errors.New("organization ID cannot be empty")
+)
+
+// HTTPError represents an HTTP error response.
+type HTTPError struct {
+	StatusCode int
+	Status     string
+	Operation  string
+	Body       []byte
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("unsuccessful request to %s: %s", e.Operation, e.Status)
+}
+
+// NewHTTPError creates a new HTTPError with the given parameters.
+func NewHTTPError(statusCode int, status, operation string, body []byte) *HTTPError {
+	return &HTTPError{
+		StatusCode: statusCode,
+		Status:     status,
+		Operation:  operation,
+		Body:       body,
+	}
+}

--- a/internal/settings/types.go
+++ b/internal/settings/types.go
@@ -1,0 +1,29 @@
+package settings
+
+import "github.com/google/uuid"
+
+// Type aliases for better readability and type safety.
+type (
+	// OrgID represents a Snyk OrgID.
+	OrgID = uuid.UUID
+)
+
+// ResponseReachability contains reachability settings from the API response.
+type ResponseReachability struct {
+	Enabled bool `json:"enabled"`
+}
+
+// ResponseAttributes contains the attributes from a reachability settings response.
+type ResponseAttributes struct {
+	Reachability ResponseReachability `json:"reachability"`
+}
+
+// ResponseData contains the data from a reachability settings response.
+type ResponseData struct {
+	Attributes ResponseAttributes `json:"attributes"`
+}
+
+// ResponseBody is the top-level response body for reachability settings.
+type ResponseBody struct {
+	Data ResponseData `json:"data"`
+}


### PR DESCRIPTION
# What this does?

Adds a settings client. This will be used during command invocation, to check whether the user's org has the reachability settings enabled.