### PR TITLE
fix: create the settings client only if needed

### DIFF
--- a/internal/commands/osmonitor/workflow.go
+++ b/internal/commands/osmonitor/workflow.go
@@ -3,6 +3,7 @@ package osmonitor
 import (
 	"context"
 	"fmt"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/code_workflow"
 	"os"
 
 	"github.com/google/uuid"
@@ -136,9 +137,5 @@ func OSWorkflow(
 		legacyArgs = append(legacyArgs, fmt.Sprintf("--reachability-id=%s", scanID))
 	}
 
-	engine := ictx.GetEngine()
-	cfg.Set(configuration.WORKFLOW_USE_STDIO, true)
-	cfg.Set(configuration.RAW_CMD_ARGS, legacyArgs)
-	//nolint:wrapcheck // No need to wrap the error since the legacy CLI will be invoked.
-	return engine.InvokeWithConfig(workflow.NewWorkflowIdentifier("legacycli"), cfg)
+	return code_workflow.EntryPointLegacy(ictx)
 }

--- a/internal/commands/osmonitor/workflow.go
+++ b/internal/commands/osmonitor/workflow.go
@@ -28,6 +28,7 @@ const FeatureFlagReachabilityForCLI = "feature_flag_monitor_reachability"
 
 // RegisterWorkflows registers the "monitor" workflow.
 func RegisterWorkflows(e workflow.Engine) error {
+	println("RegisterWorkflows")
 	// Check if workflow already exists
 	if _, ok := e.GetWorkflow(WorkflowID); ok {
 		return fmt.Errorf("workflow with ID %s already exists", WorkflowID)
@@ -49,6 +50,7 @@ func runReachabilityScan(
 	ctx context.Context,
 	ictx workflow.InvocationContext,
 ) (uuid.UUID, error) {
+	println("runReachabilityScan")
 	cfg := ictx.GetConfiguration()
 	logger := ictx.GetEnhancedLogger()
 	errFactory := errors.NewErrorFactory(logger)
@@ -116,6 +118,10 @@ func OSWorkflow(
 	ictx workflow.InvocationContext,
 	_ []workflow.Data,
 ) ([]workflow.Data, error) {
+	println("OS workflow")
+	if 2+2 == 4 {
+		return nil, fmt.Errorf("error from OS workflow")
+	}
 	ctx := context.Background()
 	cfg := ictx.GetConfiguration()
 	legacyArgs := os.Args[1:]

--- a/internal/commands/ostest/workflow.go
+++ b/internal/commands/ostest/workflow.go
@@ -259,8 +259,8 @@ func OSWorkflow( //nolint:gocyclo // Will be addressed in a refactor.
 		return nil, fmt.Errorf("orgID is not a valid UUID: %w", err)
 	}
 
-	sc := setupSettingsClient(ictx)
 	if reachability {
+		sc := setupSettingsClient(ictx)
 		//nolint:govet // Shadowing err is not an issue here.
 		isReachEnabled, err := sc.IsReachabilityEnabled(ctx, orgUUID)
 		if err != nil {


### PR DESCRIPTION
Previously the settings client was set up every time even if it wasn't needed. This was probably OK in and of itself but broke some acceptance tests in the CLI.