### PR TITLE
fix: severity threshold default 

### DIFF
--- a/internal/commands/ostest/workflow.go
+++ b/internal/commands/ostest/workflow.go
@@ -233,8 +233,14 @@ func CreateLocalPolicy(config configuration.Configuration, logger *zerolog.Logge
 	severityThreshold := getSeverityThreshold(config)
 	reachabilityFilter := getReachabilityFilter(config)
 
+	// if everything is nil, return nil for local policy
 	if riskScoreThreshold == nil && severityThreshold == nil && reachabilityFilter == nil {
 		return nil
+	}
+
+	// if we have some policy but no severity threshold, default to None
+	if severityThreshold == nil {
+		severityThreshold = util.Ptr(testapi.SeverityNone)
 	}
 
 	return &testapi.LocalPolicy{

--- a/internal/commands/ostest/workflow_test.go
+++ b/internal/commands/ostest/workflow_test.go
@@ -84,6 +84,50 @@ func TestOSWorkflow_CreateLocalPolicy_RiskScoreOverflow(t *testing.T) {
 	assert.Equal(t, uint16(math.MaxUint16), *localPolicy.RiskScoreThreshold)
 }
 
+func TestOSWorkflow_CreateLocalPolicy_SeverityThresholdDefaultsToNone(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockEngine := mocks.NewMockEngine(ctrl)
+	mockInvocationCtx := createMockInvocationCtxWithURL(t, ctrl, mockEngine, "")
+	mockConfig := mockInvocationCtx.GetConfiguration()
+
+	mockConfig.Set(flags.FlagRiskScoreThreshold, 100)
+	mockConfig.Set(flags.FlagSeverityThreshold, "")
+
+	localPolicy := ostest.CreateLocalPolicy(mockConfig, &logger)
+	require.NotNil(t, localPolicy)
+
+	require.NotNil(t, localPolicy.RiskScoreThreshold)
+	assert.Equal(t, uint16(100), *localPolicy.RiskScoreThreshold)
+
+	require.NotNil(t, localPolicy.SeverityThreshold)
+	assert.Equal(t, testapi.SeverityNone, *localPolicy.SeverityThreshold)
+}
+
+func TestOSWorkflow_CreateLocalPolicy_ReachabilityFilterDefaultBehavior(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockEngine := mocks.NewMockEngine(ctrl)
+	mockInvocationCtx := createMockInvocationCtxWithURL(t, ctrl, mockEngine, "")
+	mockConfig := mockInvocationCtx.GetConfiguration()
+
+	mockConfig.Set(flags.FlagRiskScoreThreshold, 100)
+	mockConfig.Set(flags.FlagReachabilityFilter, "")
+
+	localPolicy := ostest.CreateLocalPolicy(mockConfig, &logger)
+	require.NotNil(t, localPolicy)
+
+	require.NotNil(t, localPolicy.RiskScoreThreshold)
+	assert.Equal(t, uint16(100), *localPolicy.RiskScoreThreshold)
+
+	require.NotNil(t, localPolicy.SeverityThreshold)
+	assert.Equal(t, testapi.SeverityNone, *localPolicy.SeverityThreshold)
+
+	assert.Nil(t, localPolicy.ReachabilityFilter)
+}
+
 func TestOSWorkflow_CreateLocalPolicy_ReachabilityFilter(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
Setting the severity threshold to SeverityNone if some local policy is available such as `reachability-filters` otherwise if no policy is set the severity-threshold should be set to `nil` which will default to `Low` 