### PR TITLE
fix: map uv to correct semver definition

### DIFF
--- a/pkg/semver/composer/js/package-lock.json
+++ b/pkg/semver/composer/js/package-lock.json
@@ -8,7 +8,7 @@
       "name": "composer-semver",
       "version": "0.0.1",
       "dependencies": {
-        "@snyk/composer-semver": "^1"
+        "@snyk/composer-semver": "^1.1.1"
       },
       "devDependencies": {
         "esbuild": "^0"
@@ -434,6 +434,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@snyk/composer-semver/-/composer-semver-1.1.1.tgz",
       "integrity": "sha512-dUzSPFM7yrCczmLXQwm1p44LclS3bWvFdKxgPz3q6RMy45HrWkSe91G9sIz1vANuz+AgXmitbWQ9X/PdvqwW2g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@snyk/ruby-semver": "^2.1.0",
         "@types/lodash": "^4.14.149",
@@ -529,9 +530,11 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
+      "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
+      "deprecated": "Bad release. Please use lodash@4.17.21 instead.",
+      "license": "MIT"
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",

--- a/pkg/semver/composer/js/package.json
+++ b/pkg/semver/composer/js/package.json
@@ -2,6 +2,9 @@
   "dependencies": {
     "@snyk/composer-semver": "^1"
   },
+  "overrides": {
+    "lodash": ">=4.17.23"
+  },
   "devDependencies": {
     "esbuild": "^0"
   },

--- a/pkg/semver/semver.go
+++ b/pkg/semver/semver.go
@@ -76,7 +76,7 @@ func GetSemver(pkgManager string) (shared.Runtime, error) {
 	case "composer":
 		return Composer()
 	case "maven", "gradle", "sbt",
-		"pip", "poetry", "pipenv":
+		"pip", "poetry", "pipenv", "uv":
 		return Maven()
 	case "nuget", "packet":
 		return Nuget()


### PR DESCRIPTION
We are running into issues with SBOM tests of uv projects due to a missing mapping. This PR adds the relevant mapping.

I also added an override for a vuln in lodash which is pulled in by `@snyk/composer-semver`.