### PR TITLE
feat: send target and project identity for dragonfly `snyk test`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/dop251/goja v0.0.0-20251008123653-cf18d89f3cf6
 	github.com/dop251/goja_nodejs v0.0.0-20250409162600-f7acab6894b0
 	github.com/gkampitakis/go-snaps v0.5.14
+	github.com/go-git/go-git/v5 v5.16.5
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/puddle/v2 v2.2.2
@@ -52,7 +53,6 @@ require (
 	github.com/gkampitakis/go-diff v1.3.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
-	github.com/go-git/go-git/v5 v5.16.5 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-yaml v1.18.0 // indirect

--- a/internal/commands/ostest/__snapshots__/dfly_depgraph_flow_test.snap
+++ b/internal/commands/ostest/__snapshots__/dfly_depgraph_flow_test.snap
@@ -86,7 +86,7 @@
 [Test_RunDflyDepgraphFlow_JSON - 1]
 {
  "dependencyCount": 0,
- "displayTargetFile": "",
+ "displayTargetFile": "proj/package.json",
  "filesystemPolicy": false,
  "filtered": {
   "ignore": [],
@@ -126,7 +126,7 @@
   }
  },
  "summary": "1 vulnerable dependency path",
- "targetFile": "",
+ "targetFile": "proj/package.json",
  "uniqueCount": 1,
  "vulnerabilities": [
   {
@@ -324,7 +324,7 @@
 [Test_RunDflyDepgraphFlow_HumanReadable - 3]
 {
  "dependencyCount": 0,
- "displayTargetFile": "",
+ "displayTargetFile": "proj/package.json",
  "packageManager": "",
  "projectName": "",
  "summary": {

--- a/internal/commands/ostest/dfly_depgraph_flow.go
+++ b/internal/commands/ostest/dfly_depgraph_flow.go
@@ -12,9 +12,11 @@ import (
 	"github.com/snyk/cli-extension-os-flows/internal/constants"
 	"github.com/snyk/cli-extension-os-flows/internal/legacy/definitions"
 	"github.com/snyk/cli-extension-os-flows/internal/reachability"
+	"github.com/snyk/cli-extension-os-flows/pkg/flags"
 
 	"github.com/google/uuid"
 	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
+	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
@@ -96,15 +98,30 @@ func RunDflyDepgraphFlow(
 		return nil, nil, fmt.Errorf("failed to upload dependency graphs: %w", err)
 	}
 
-	uploadResource, err := newUploadResource(uploadRes.RevisionID.String(), testapi.UploadResourceContentTypeSbom)
+	cfg := cmdctx.Config(ctx)
+
+	if override := cfg.GetString(flags.FlagProjectName); override != "" {
+		for i := range depGraphs {
+			depGraphs[i].Identity.Name = override
+		}
+	}
+
+	scmInfo := ResolveScmInfo(inputDir, cfg.GetString(flags.FlagRemoteRepoURL), logger)
+
+	var scmCtx *testapi.ScmContext
+	if scmInfo != nil {
+		scmCtx = &testapi.ScmContext{
+			RepoUrl: &scmInfo.RemoteURL,
+			Branch:  &scmInfo.Branch,
+		}
+	}
+
+	uploadResource, err := newUploadResource(uploadRes.RevisionID.String(), testapi.UploadResourceContentTypeSbom, scmCtx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create upload resource: %w", err)
 	}
 
 	resources := []testapi.TestResourceCreateItem{uploadResource}
-	scanConfig := &testapi.ScanConfiguration{
-		Sca: &testapi.ScaScanConfiguration{},
-	}
 
 	if reachabilityOpts != nil {
 		progressBar.SetTitle(constants.UploadingSourceCodeMessage)
@@ -120,8 +137,16 @@ func RunDflyDepgraphFlow(
 		}
 	}
 
+	testConfig := buildTestConfig(cfg, localPolicy)
+
+	projectName := depGraphs[0].Identity.Name
+	targetFile := depGraphs[0].Identity.TargetFile
+
 	osAnalysisStart := time.Now()
-	legacyVuln, wfData, err := RunTestWithResources(ctx, inputDir, clients.TestClient, resources, "", "", 0, "", "", orgUUID.String(), localPolicy, scanConfig)
+	legacyVuln, wfData, err := RunTestWithResources(
+		ctx, inputDir, clients.TestClient, resources,
+		projectName, "", 0, targetFile, targetFile, orgUUID.String(), testConfig,
+	)
 	if instrumentation != nil {
 		instrumentation.RecordOSAnalysisTime(time.Since(osAnalysisStart).Milliseconds())
 	}
@@ -132,4 +157,17 @@ func RunDflyDepgraphFlow(
 	}
 
 	return legacyVulnRes, wfData, err
+}
+
+func buildTestConfig(cfg configuration.Configuration, localPolicy *testapi.LocalPolicy) *testapi.TestConfiguration {
+	testConfig := &testapi.TestConfiguration{
+		LocalPolicy: localPolicy,
+		ScanConfig: &testapi.ScanConfiguration{
+			Sca: &testapi.ScaScanConfiguration{},
+		},
+	}
+	if tr := cfg.GetString(flags.FlagTargetReference); tr != "" {
+		testConfig.TargetReference = &tr
+	}
+	return testConfig
 }

--- a/internal/commands/ostest/sbom_flow.go
+++ b/internal/commands/ostest/sbom_flow.go
@@ -43,7 +43,7 @@ func RunSbomFlow(
 	}
 	logger.Debug().Str("sbomRevisionID", sbomResult.RevisionID.String()).Msg("SBOM uploaded successfully")
 
-	sbomResource, err := newUploadResource(sbomResult.RevisionID.String(), testapi.UploadResourceContentTypeSbom)
+	sbomResource, err := newUploadResource(sbomResult.RevisionID.String(), testapi.UploadResourceContentTypeSbom, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create SBOM resource: %w", err)
 	}
@@ -64,8 +64,11 @@ func RunSbomFlow(
 	targetDir := filepath.Dir(sbomPath)
 	osAnalysisStart := time.Now()
 
-	scanConfig := &testapi.ScanConfiguration{
-		Sca: &testapi.ScaScanConfiguration{},
+	testConfig := &testapi.TestConfiguration{
+		LocalPolicy: localPolicy,
+		ScanConfig: &testapi.ScanConfiguration{
+			Sca: &testapi.ScaScanConfiguration{},
+		},
 	}
 
 	findings, summary, err := RunTestWithResources(
@@ -79,8 +82,7 @@ func RunSbomFlow(
 		sbomPath,
 		sbomPath,
 		orgUUID.String(),
-		localPolicy,
-		scanConfig,
+		testConfig,
 	)
 	if err != nil {
 		return nil, nil, err
@@ -114,16 +116,17 @@ func uploadSourceCodeResource(
 	}
 	logger.Debug().Str("sourceRevisionID", sourceResult.RevisionID.String()).Msg("Source code uploaded successfully")
 
-	return newUploadResource(sourceResult.RevisionID.String(), testapi.UploadResourceContentTypeSource)
+	return newUploadResource(sourceResult.RevisionID.String(), testapi.UploadResourceContentTypeSource, nil)
 }
 
-// newUploadResource creates a TestResourceCreateItem from a revision ID and content type.
-func newUploadResource(revisionID string, contentType testapi.UploadResourceContentType) (testapi.TestResourceCreateItem, error) {
+// newUploadResource creates a TestResourceCreateItem from a revision ID, content type, and optional SCM context.
+func newUploadResource(revisionID string, contentType testapi.UploadResourceContentType, scmCtx *testapi.ScmContext) (testapi.TestResourceCreateItem, error) {
 	uploadResource := testapi.UploadResource{
 		ContentType:  contentType,
 		FilePatterns: []string{},
 		RevisionId:   revisionID,
 		Type:         testapi.Upload,
+		ScmContext:   scmCtx,
 	}
 
 	var resourceVariant testapi.BaseResourceVariantCreateItem

--- a/internal/commands/ostest/scm_info.go
+++ b/internal/commands/ostest/scm_info.go
@@ -1,0 +1,38 @@
+package ostest
+
+import (
+	"github.com/rs/zerolog"
+	"github.com/snyk/go-application-framework/pkg/utils/git"
+)
+
+// ScmInfo holds SCM metadata resolved from the local git repository.
+type ScmInfo struct {
+	RemoteURL string
+	Branch    string
+}
+
+// ResolveScmInfo resolves SCM info from the git repository at inputDir.
+// If remoteURLOverride is non-empty it takes precedence over the detected URL.
+// Both lookups are best-effort: failures are logged at Debug level and never propagated.
+// Returns nil when no remote URL can be determined (no override and git lookup fails).
+func ResolveScmInfo(inputDir, remoteURLOverride string, logger *zerolog.Logger) *ScmInfo {
+	remoteURL := remoteURLOverride
+	if remoteURL == "" {
+		detected, err := git.GetRemoteUrl(inputDir)
+		if err != nil {
+			logger.Warn().Err(err).Msg("Could not resolve git remote URL, proceeding without SCM context")
+			return nil
+		}
+		remoteURL = detected
+	}
+
+	branch, err := git.BranchNameFromDir(inputDir)
+	if err != nil {
+		logger.Warn().Err(err).Msg("Could not resolve git branch, proceeding without branch in SCM context")
+	}
+
+	return &ScmInfo{
+		RemoteURL: remoteURL,
+		Branch:    branch,
+	}
+}

--- a/internal/commands/ostest/scm_info_test.go
+++ b/internal/commands/ostest/scm_info_test.go
@@ -1,0 +1,91 @@
+package ostest_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-os-flows/internal/commands/ostest"
+)
+
+func TestResolveScmInfo(t *testing.T) {
+	nop := zerolog.Nop()
+
+	t.Run("returns remote url and branch from git repo", func(t *testing.T) {
+		dir := initGitRepo(t, "https://github.com/acme/repo.git")
+
+		info := ostest.ResolveScmInfo(dir, "", &nop)
+
+		require.NotNil(t, info)
+		assert.Equal(t, "https://github.com/acme/repo.git", info.RemoteURL)
+		assert.Equal(t, "main", info.Branch)
+	})
+
+	t.Run("override replaces detected remote url", func(t *testing.T) {
+		dir := initGitRepo(t, "https://github.com/acme/repo.git")
+
+		info := ostest.ResolveScmInfo(dir, "https://custom.example.com/override.git", &nop)
+
+		require.NotNil(t, info)
+		assert.Equal(t, "https://custom.example.com/override.git", info.RemoteURL)
+	})
+
+	t.Run("returns nil for non-git directory", func(t *testing.T) {
+		dir := t.TempDir()
+
+		info := ostest.ResolveScmInfo(dir, "", &nop)
+
+		assert.Nil(t, info)
+	})
+
+	t.Run("override with non-git directory still returns info", func(t *testing.T) {
+		dir := t.TempDir()
+
+		info := ostest.ResolveScmInfo(dir, "https://override.example.com/repo.git", &nop)
+
+		require.NotNil(t, info)
+		assert.Equal(t, "https://override.example.com/repo.git", info.RemoteURL)
+		assert.Empty(t, info.Branch)
+	})
+}
+
+func initGitRepo(t *testing.T, remoteURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	repo, err := gogit.PlainInitWithOptions(dir, &gogit.PlainInitOptions{
+		InitOptions: gogit.InitOptions{
+			DefaultBranch: plumbing.NewBranchReferenceName("main"),
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = repo.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{remoteURL},
+	})
+	require.NoError(t, err)
+
+	// Create an initial commit so HEAD exists with a branch ref.
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	f, err := os.CreateTemp(dir, "init")
+	require.NoError(t, err)
+	f.Close()
+	_, err = wt.Add(f.Name()[len(dir)+1:])
+	require.NoError(t, err)
+	_, err = wt.Commit("init", &gogit.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+
+	return dir
+}

--- a/internal/commands/ostest/test_execution.go
+++ b/internal/commands/ostest/test_execution.go
@@ -69,11 +69,9 @@ func RunTestWithResources(
 	targetFile string,
 	displayTargetFile string,
 	orgID string,
-	localPolicy *testapi.LocalPolicy,
-	scanConfig *testapi.ScanConfiguration,
+	testConfig *testapi.TestConfiguration,
 ) (*definitions.LegacyVulnerabilityResponse, []workflow.Data, error) {
-	testConfig := testapi.TestConfiguration{LocalPolicy: localPolicy, ScanConfig: scanConfig}
-	startParams := testapi.NewStartTestParamsFromResources(orgID, &resources, &testConfig)
+	startParams := testapi.NewStartTestParamsFromResources(orgID, &resources, testConfig)
 	return runTestInternal(ctx, targetDir, testClient, startParams, projectName, packageManager, depCount, targetFile, displayTargetFile)
 }
 

--- a/internal/commands/ostest/test_execution_test.go
+++ b/internal/commands/ostest/test_execution_test.go
@@ -382,7 +382,7 @@ func Test_RunTestWithResources_ErrorsWhenFindingsError(t *testing.T) {
 
 	resources := []testapi.TestResourceCreateItem{}
 
-	_, _, err := ostest.RunTestWithResources(ctx, ".", mockTestClient, resources, "", "", 0, "", "", "org", nil, nil)
+	_, _, err := ostest.RunTestWithResources(ctx, ".", mockTestClient, resources, "", "", 0, "", "", "org", nil)
 	require.Error(t, err)
 }
 
@@ -410,6 +410,6 @@ func Test_RunTestWithResources_ErrorsWhenFindingsIncomplete(t *testing.T) {
 
 	resources := []testapi.TestResourceCreateItem{}
 
-	_, _, err := ostest.RunTestWithResources(ctx, ".", mockTestClient, resources, "", "", 0, "", "", "org", nil, nil)
+	_, _, err := ostest.RunTestWithResources(ctx, ".", mockTestClient, resources, "", "", 0, "", "", "org", nil)
 	require.Error(t, err)
 }

--- a/internal/common/depgraph_resolver.go
+++ b/internal/common/depgraph_resolver.go
@@ -25,6 +25,22 @@ type DepgraphWithIdentity struct {
 	Identity Identity           `json:"identity"`
 }
 
+// BuildIdentity constructs an Identity from a depgraph and its associated metadata.
+func BuildIdentity(dg *depgraph.DepGraph, targetFile, runtime string) Identity {
+	id := Identity{TargetFile: targetFile}
+	if runtime != "" {
+		id.TargetRuntime = &runtime
+	}
+	if dg == nil {
+		return id
+	}
+	id.Type = dg.PkgManager.Name
+	if rootPkg := dg.GetRootPkg(); rootPkg != nil {
+		id.Name = rootPkg.Info.Name
+	}
+	return id
+}
+
 type depgraphResolver struct{}
 
 // DepgraphResolver is the interface for resolving dependency graphs with their associated identities.
@@ -62,9 +78,7 @@ func (dr *depgraphResolver) GetDepGraphsWithIdentity(ictx workflow.InvocationCon
 		}
 		dgs = append(dgs, DepgraphWithIdentity{
 			DepGraph: res.DepGraph,
-			Identity: Identity{
-				TargetFile: res.Metadata.TargetFile,
-			},
+			Identity: BuildIdentity(res.DepGraph, res.Metadata.TargetFile, res.Metadata.Runtime),
 		})
 	}
 

--- a/internal/common/depgraph_resolver_test.go
+++ b/internal/common/depgraph_resolver_test.go
@@ -1,0 +1,98 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/snyk/dep-graph/go/pkg/depgraph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	service "github.com/snyk/cli-extension-os-flows/internal/common"
+)
+
+func TestBuildIdentity(t *testing.T) {
+	t.Run("populates all fields from depgraph", func(t *testing.T) {
+		dg := newDepGraph(t, "npm", "my-project@1.0.0", "my-project", "1.0.0")
+
+		id := service.BuildIdentity(dg, "proj/package.json", "node@18.0.0")
+
+		assert.Equal(t, "my-project", id.Name)
+		assert.Equal(t, "npm", id.Type)
+		assert.Equal(t, "proj/package.json", id.TargetFile)
+		require.NotNil(t, id.TargetRuntime)
+		assert.Equal(t, "node@18.0.0", *id.TargetRuntime)
+	})
+
+	t.Run("empty runtime produces nil pointer", func(t *testing.T) {
+		dg := newDepGraph(t, "npm", "proj@1.0.0", "proj", "1.0.0")
+
+		id := service.BuildIdentity(dg, "package.json", "")
+
+		assert.Nil(t, id.TargetRuntime)
+	})
+
+	t.Run("empty pkg manager", func(t *testing.T) {
+		dg := newDepGraph(t, "", "app@2.0.0", "app", "2.0.0")
+
+		id := service.BuildIdentity(dg, "pom.xml", "")
+
+		assert.Equal(t, "app", id.Name)
+		assert.Equal(t, "", id.Type)
+		assert.Equal(t, "pom.xml", id.TargetFile)
+	})
+
+	t.Run("nil depgraph", func(t *testing.T) {
+		id := service.BuildIdentity(nil, "some/path", "python@3.11")
+
+		assert.Equal(t, "", id.Name)
+		assert.Equal(t, "", id.Type)
+		assert.Equal(t, "some/path", id.TargetFile)
+		require.NotNil(t, id.TargetRuntime)
+		assert.Equal(t, "python@3.11", *id.TargetRuntime)
+	})
+
+	t.Run("no root pkg", func(t *testing.T) {
+		dg := &depgraph.DepGraph{
+			SchemaVersion: "1.2.0",
+			PkgManager:    depgraph.PkgManager{Name: "maven"},
+			Pkgs:          []depgraph.Pkg{},
+			Graph:         depgraph.Graph{RootNodeID: "root", Nodes: []depgraph.Node{}},
+		}
+		require.NoError(t, dg.BuildGraph())
+
+		id := service.BuildIdentity(dg, "pom.xml", "")
+
+		assert.Equal(t, "", id.Name)
+		assert.Equal(t, "maven", id.Type)
+		assert.Equal(t, "pom.xml", id.TargetFile)
+	})
+
+	t.Run("empty target file", func(t *testing.T) {
+		dg := newDepGraph(t, "pip", "mylib@0.1.0", "mylib", "0.1.0")
+
+		id := service.BuildIdentity(dg, "", "python@3.11.0")
+
+		assert.Equal(t, "mylib", id.Name)
+		assert.Equal(t, "pip", id.Type)
+		assert.Equal(t, "", id.TargetFile)
+		require.NotNil(t, id.TargetRuntime)
+		assert.Equal(t, "python@3.11.0", *id.TargetRuntime)
+	})
+}
+
+func newDepGraph(t *testing.T, pkgManager, rootID, rootName, rootVersion string) *depgraph.DepGraph {
+	t.Helper()
+	dg := &depgraph.DepGraph{
+		SchemaVersion: "1.2.0",
+		PkgManager:    depgraph.PkgManager{Name: pkgManager},
+		Pkgs: []depgraph.Pkg{
+			{ID: rootID, Info: depgraph.PkgInfo{Name: rootName, Version: rootVersion}},
+		},
+		Graph: depgraph.Graph{
+			RootNodeID: "root",
+			Nodes:      []depgraph.Node{{NodeID: "root", PkgID: rootID}},
+		},
+	}
+	require.NoError(t, dg.BuildGraph())
+	return dg
+}

--- a/pkg/semver/composer/js/package-lock.json
+++ b/pkg/semver/composer/js/package-lock.json
@@ -8,7 +8,7 @@
       "name": "composer-semver",
       "version": "0.0.1",
       "dependencies": {
-        "@snyk/composer-semver": "^1.1.1"
+        "@snyk/composer-semver": "^1"
       },
       "devDependencies": {
         "esbuild": "^0"
@@ -530,11 +530,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
-      "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
-      "deprecated": "Bad release. Please use lodash@4.17.21 instead.",
-      "license": "MIT"
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",

--- a/pkg/semver/composer/js/package.json
+++ b/pkg/semver/composer/js/package.json
@@ -3,7 +3,7 @@
     "@snyk/composer-semver": "^1"
   },
   "overrides": {
-    "lodash": ">=4.17.23"
+    "lodash": ">=4.18.1"
   },
   "devDependencies": {
     "esbuild": "^0"


### PR DESCRIPTION
# What this does?

Sends target and project identity during a dragonfly `snyk test`.