### PR TITLE
refactor: Align ostest with slim TestResult metadata

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,6 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260205094614-116c03822905 h1:pUe6iOWHEOFY0t4u4ssXeTqpMmZBu1xq06VBFI9zUik=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260205094614-116c03822905/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.0.0-20260330124826-9560aa9edaf6 h1:Ltb6illIasRhS/MKZX2+uLtDyuxWWvDPYQJzv41EwM8=
-github.com/snyk/go-application-framework v0.0.0-20260330124826-9560aa9edaf6/go.mod h1:7IOOtKxiQhtTbkrX7rax20QNJ/rwGill6n2Rejtld2I=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/internal/commands/ostest/depgraph_flow_test.go
+++ b/internal/commands/ostest/depgraph_flow_test.go
@@ -135,9 +135,9 @@ func newMockDepGraphDatas(t *testing.T, ctrl *gomock.Controller, n int) []workfl
 
 func newPassingTestResult(ctrl *gomock.Controller) *gafclientmocks.MockTestResult {
 	result := gafclientmocks.NewMockTestResult(ctrl)
+	emptyMeta := make(map[string]interface{})
 	result.EXPECT().GetExecutionState().Return(testapi.TestExecutionStatesFinished).AnyTimes()
 	result.EXPECT().Findings(gomock.Any()).Return([]testapi.FindingData{}, true, nil).AnyTimes()
-	result.EXPECT().GetSubjectLocators().Return(nil).AnyTimes()
 	result.EXPECT().GetTestID().Return(&uuid.UUID{}).AnyTimes()
 	result.EXPECT().GetTestConfiguration().Return(&testapi.TestConfiguration{}).AnyTimes()
 	result.EXPECT().GetCreatedAt().Return(&time.Time{}).AnyTimes()
@@ -148,12 +148,9 @@ func newPassingTestResult(ctrl *gomock.Controller) *gafclientmocks.MockTestResul
 	outcomeReason := testapi.TestOutcomeReasonOther
 	result.EXPECT().GetOutcomeReason().Return(&outcomeReason).AnyTimes()
 	result.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).Return().AnyTimes()
-	result.EXPECT().GetMetadata().Return(make(map[string]interface{})).AnyTimes()
-	result.EXPECT().GetTestFacts().Return(nil).AnyTimes()
-	result.EXPECT().GetBreachedPolicies().Return(&testapi.PolicyRefSet{}).AnyTimes()
-	result.EXPECT().GetTestSubject().Return(&testapi.TestSubject{}).AnyTimes()
+	result.EXPECT().GetMetadataValue(gomock.Any()).Return(nil).AnyTimes()
+	result.EXPECT().ShallowMetadataCopy().Return(emptyMeta).AnyTimes()
 	result.EXPECT().GetEffectiveSummary().Return(&testapi.FindingSummary{}).AnyTimes()
-	result.EXPECT().GetRawSummary().Return(&testapi.FindingSummary{}).AnyTimes()
 	return result
 }
 

--- a/internal/commands/ostest/dfly_depgraph_flow_test.go
+++ b/internal/commands/ostest/dfly_depgraph_flow_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/snyk/cli-extension-os-flows/internal/commands/ostest"
 	service "github.com/snyk/cli-extension-os-flows/internal/common"
 	"github.com/snyk/cli-extension-os-flows/internal/outputworkflow"
-	"github.com/snyk/cli-extension-os-flows/internal/util"
 )
 
 func Test_RunDflyDepgraphFlow_JSON(t *testing.T) {
@@ -255,21 +254,15 @@ func setupTestClient(t *testing.T, ctrl *gomock.Controller) *gafclientmocks.Mock
 	mockTestResult := gafclientmocks.NewMockTestResult(ctrl)
 	mockTestResult.EXPECT().GetExecutionState().Return(testapi.TestExecutionStatesFinished).AnyTimes()
 	mockTestResult.EXPECT().Findings(gomock.Any()).Return([]testapi.FindingData{aFinding(t)}, true, nil).AnyTimes()
-	mockTestResult.EXPECT().GetTestSubject().Return(nil).AnyTimes()
 	mockTestResult.EXPECT().GetEffectiveSummary().Return(summary).AnyTimes()
-	mockTestResult.EXPECT().GetRawSummary().Return(summary).AnyTimes()
 
-	var tsl testapi.TestSubjectLocator
 	projectID := uuid.MustParse("5c520c95-a964-4de0-9284-02a16f9f88d5")
-	err := tsl.FromProjectEntityLocator(testapi.ProjectEntityLocator{
-		ProjectId: projectID,
-		Type:      testapi.ProjectEntity,
-	})
-	require.NoError(t, err)
+	resultMeta := map[string]interface{}{
+		testapi.MetadataKeyProjectID: projectID.String(),
+	}
 
 	passFail := testapi.Pass
 	outcomeReason := testapi.TestOutcomeReasonOther
-	mockTestResult.EXPECT().GetSubjectLocators().Return(util.Ptr([]testapi.TestSubjectLocator{tsl})).AnyTimes()
 	mockTestResult.EXPECT().GetTestID().Return(&uuid.UUID{}).AnyTimes()
 	mockTestResult.EXPECT().GetTestConfiguration().Return(&testapi.TestConfiguration{}).AnyTimes()
 	mockTestResult.EXPECT().GetCreatedAt().Return(&time.Time{}).AnyTimes()
@@ -278,9 +271,10 @@ func setupTestClient(t *testing.T, ctrl *gomock.Controller) *gafclientmocks.Mock
 	mockTestResult.EXPECT().GetPassFail().Return(&passFail).AnyTimes()
 	mockTestResult.EXPECT().GetOutcomeReason().Return(&outcomeReason).AnyTimes()
 	mockTestResult.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).Return().AnyTimes()
-	mockTestResult.EXPECT().GetMetadata().Return(make(map[string]interface{})).AnyTimes()
-	mockTestResult.EXPECT().GetTestFacts().Return(nil).AnyTimes()
-	mockTestResult.EXPECT().GetBreachedPolicies().Return(&testapi.PolicyRefSet{}).AnyTimes()
+	mockTestResult.EXPECT().GetMetadataValue(gomock.Any()).DoAndReturn(func(key string) interface{} {
+		return resultMeta[key]
+	}).AnyTimes()
+	mockTestResult.EXPECT().ShallowMetadataCopy().Return(resultMeta).AnyTimes()
 
 	mockTestHandle := gafclientmocks.NewMockTestHandle(ctrl)
 	mockTestHandle.EXPECT().Wait(gomock.Any()).Return(nil).Times(1)

--- a/internal/commands/ostest/sbom_flow_test.go
+++ b/internal/commands/ostest/sbom_flow_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/snyk/cli-extension-os-flows/internal/deeproxy"
 	"github.com/snyk/cli-extension-os-flows/internal/errors"
 	"github.com/snyk/cli-extension-os-flows/internal/outputworkflow"
-	"github.com/snyk/cli-extension-os-flows/internal/util"
 )
 
 // idRgxp is used for replacing the "id" in the output for snapshot consistency.
@@ -438,12 +437,14 @@ func setupTest(
 	mockTestResult := gafclientmocks.NewMockTestResult(ctrl)
 	mockTestResult.EXPECT().GetExecutionState().Return(testapi.TestExecutionStatesFinished).AnyTimes()
 	mockTestResult.EXPECT().Findings(gomock.Any()).Return([]testapi.FindingData{findingData}, true, nil).AnyTimes()
-	mockTestResult.EXPECT().GetTestSubject().Return(nil).AnyTimes()
 	mockTestResult.EXPECT().GetEffectiveSummary().Return(summary).AnyTimes()
-	mockTestResult.EXPECT().GetRawSummary().Return(summary).AnyTimes()
 
 	passFail := testapi.Pass
 	outcomeReason := testapi.TestOutcomeReasonOther
+	projectID := uuid.MustParse("5c520c95-a964-4de0-9284-02a16f9f88d5")
+	resultMeta := map[string]interface{}{
+		testapi.MetadataKeyProjectID: projectID.String(),
+	}
 	// Mock calls for serialized test result
 	mockTestResult.EXPECT().GetTestID().Return(&uuid.UUID{}).AnyTimes()
 	mockTestResult.EXPECT().GetTestConfiguration().Return(&testapi.TestConfiguration{}).AnyTimes()
@@ -453,18 +454,10 @@ func setupTest(
 	mockTestResult.EXPECT().GetPassFail().Return(&passFail).AnyTimes()
 	mockTestResult.EXPECT().GetOutcomeReason().Return(&outcomeReason).AnyTimes()
 	mockTestResult.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).Return().AnyTimes()
-	mockTestResult.EXPECT().GetMetadata().Return(make(map[string]interface{})).AnyTimes()
-	mockTestResult.EXPECT().GetTestFacts().Return(nil).AnyTimes()
-	mockTestResult.EXPECT().GetBreachedPolicies().Return(&testapi.PolicyRefSet{}).AnyTimes()
-
-	var tsl testapi.TestSubjectLocator
-	projectID := uuid.MustParse("5c520c95-a964-4de0-9284-02a16f9f88d5")
-	err = tsl.FromProjectEntityLocator(testapi.ProjectEntityLocator{
-		ProjectId: projectID,
-		Type:      testapi.ProjectEntity,
-	})
-	require.NoError(t, err)
-	mockTestResult.EXPECT().GetSubjectLocators().Return(util.Ptr([]testapi.TestSubjectLocator{tsl})).AnyTimes()
+	mockTestResult.EXPECT().GetMetadataValue(gomock.Any()).DoAndReturn(func(key string) interface{} {
+		return resultMeta[key]
+	}).AnyTimes()
+	mockTestResult.EXPECT().ShallowMetadataCopy().Return(resultMeta).AnyTimes()
 
 	// Mock TestHandle
 	mockTestHandle := gafclientmocks.NewMockTestHandle(ctrl)

--- a/internal/commands/ostest/sbom_resolution_integration_test.go
+++ b/internal/commands/ostest/sbom_resolution_integration_test.go
@@ -134,10 +134,10 @@ func setupSBOMResolutionIntegrationTest(
 			result := gafclientmocks.NewMockTestResult(ctrl)
 			result.EXPECT().GetExecutionState().Return(testapi.TestExecutionStatesFinished).AnyTimes()
 			result.EXPECT().Findings(gomock.Any()).Return([]testapi.FindingData{}, true, nil).AnyTimes()
-			result.EXPECT().GetSubjectLocators().Return(nil).AnyTimes()
 			handle.EXPECT().Result().Return(result).Times(1)
 
 			// Mockup calls for serialized test result
+			emptyMeta := make(map[string]interface{})
 			result.EXPECT().GetTestID().Return(&uuid.UUID{}).AnyTimes()
 			result.EXPECT().GetTestConfiguration().Return(&testapi.TestConfiguration{}).AnyTimes()
 			result.EXPECT().GetCreatedAt().Return(&time.Time{}).AnyTimes()
@@ -148,12 +148,9 @@ func setupSBOMResolutionIntegrationTest(
 			outcomeReason := testapi.TestOutcomeReasonOther
 			result.EXPECT().GetOutcomeReason().Return(&outcomeReason).AnyTimes()
 			result.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).Return().AnyTimes()
-			result.EXPECT().GetMetadata().Return(make(map[string]interface{})).AnyTimes()
-			result.EXPECT().GetTestFacts().Return(nil).AnyTimes()
-			result.EXPECT().GetBreachedPolicies().Return(&testapi.PolicyRefSet{}).AnyTimes()
-			result.EXPECT().GetTestSubject().Return(&testapi.TestSubject{}).AnyTimes()
+			result.EXPECT().GetMetadataValue(gomock.Any()).Return(nil).AnyTimes()
+			result.EXPECT().ShallowMetadataCopy().Return(emptyMeta).AnyTimes()
 			result.EXPECT().GetEffectiveSummary().Return(&testapi.FindingSummary{}).AnyTimes()
-			result.EXPECT().GetRawSummary().Return(&testapi.FindingSummary{}).AnyTimes()
 
 			return handle, nil
 		}).

--- a/internal/commands/ostest/test_execution.go
+++ b/internal/commands/ostest/test_execution.go
@@ -160,46 +160,36 @@ func runTestInternal(
 }
 
 func getTestProjectID(result testapi.TestResult) (*string, error) {
-	locators := result.GetSubjectLocators()
-	if locators == nil {
+	v := result.GetMetadataValue(testapi.MetadataKeyProjectID)
+	if v == nil {
 		//nolint:nilnil // Nil is a proper value to be returned, indicating a missing project id.
 		return nil, nil
 	}
-
-	for _, loc := range *locators {
-		disc, err := loc.Discriminator()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get subject locator discriminator: %w", err)
-		}
-		if disc != string(testapi.ProjectEntity) {
-			continue
-		}
-		peLoc, err := loc.AsProjectEntityLocator()
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert subject locator to project entity locator: %w", err)
-		}
-		return util.Ptr(peLoc.ProjectId.String()), nil
+	s, ok := v.(string)
+	if !ok || s == "" {
+		//nolint:nilnil // Nil is a proper value to be returned, indicating a missing project id.
+		return nil, nil
 	}
-
-	//nolint:nilnil // Nil is a proper value to be returned, indicating a missing project id.
-	return nil, nil
+	return util.Ptr(s), nil
 }
 
-// GetDependencyCountFromTestFacts extracts the total dependency count from test facts.
-// Returns 0 if no dependency count fact is found.
+// GetDependencyCountFromTestFacts extracts the total dependency count from test result metadata.
+// Returns 0 if no dependency count is present.
 func GetDependencyCountFromTestFacts(result testapi.TestResult) int {
-	testFacts := result.GetTestFacts()
-	if testFacts == nil {
+	v := result.GetMetadataValue(testapi.MetadataKeyDependencyCount)
+	if v == nil {
 		return 0
 	}
-
-	for _, fact := range *testFacts {
-		if fact.Type == testapi.DependencyCountFactTypeDependencyCountFact {
-			return int(fact.TotalDependencyCount)
-		}
+	switch n := v.(type) {
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	default:
+		return 0
 	}
-
-	return 0
 }
 
 // executeTest runs the test with the provided parameters and returns the results.
@@ -281,11 +271,11 @@ func prepareOutput(
 	}
 
 	// set metadata on the test result
-	params.TestResult.SetMetadata("package-manager", params.PackageManager)
-	params.TestResult.SetMetadata("project-name", params.ProjectName)
-	params.TestResult.SetMetadata("display-target-file", params.DisplayTargetFile)
-	params.TestResult.SetMetadata("target-directory", params.TargetDir)
-	params.TestResult.SetMetadata("dependency-count", params.DepCount)
+	params.TestResult.SetMetadata(testapi.MetadataKeyPackageManager, params.PackageManager)
+	params.TestResult.SetMetadata(testapi.MetadataKeyProjectName, params.ProjectName)
+	params.TestResult.SetMetadata(testapi.MetadataKeyDisplayTargetFile, params.DisplayTargetFile)
+	params.TestResult.SetMetadata(testapi.MetadataKeyTargetDirectory, params.TargetDir)
+	params.TestResult.SetMetadata(testapi.MetadataKeyDependencyCount, params.DepCount)
 
 	// always output the test result
 	testResultData := ufm.CreateWorkflowDataFromTestResults(ictx.GetWorkflowIdentifier(), []testapi.TestResult{params.TestResult})

--- a/internal/commands/ostest/test_execution_test.go
+++ b/internal/commands/ostest/test_execution_test.go
@@ -294,32 +294,25 @@ func Test_GetDependencyCountFromTestFacts(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	t.Run("returns 0 when test facts is nil", func(t *testing.T) {
+	t.Run("returns 0 when metadata has no dependency count", func(t *testing.T) {
 		mockResult := gafclientmocks.NewMockTestResult(ctrl)
-		mockResult.EXPECT().GetTestFacts().Return(nil)
+		mockResult.EXPECT().GetMetadataValue(testapi.MetadataKeyDependencyCount).Return(nil)
 
 		count := ostest.GetDependencyCountFromTestFacts(mockResult)
 		assert.Equal(t, 0, count)
 	})
 
-	t.Run("returns 0 when test facts is empty", func(t *testing.T) {
+	t.Run("returns 0 when dependency count metadata is wrong type", func(t *testing.T) {
 		mockResult := gafclientmocks.NewMockTestResult(ctrl)
-		emptyFacts := []testapi.TestFact{}
-		mockResult.EXPECT().GetTestFacts().Return(&emptyFacts)
+		mockResult.EXPECT().GetMetadataValue(testapi.MetadataKeyDependencyCount).Return("not-a-number")
 
 		count := ostest.GetDependencyCountFromTestFacts(mockResult)
 		assert.Equal(t, 0, count)
 	})
 
-	t.Run("returns dependency count from test facts", func(t *testing.T) {
+	t.Run("returns dependency count from metadata", func(t *testing.T) {
 		mockResult := gafclientmocks.NewMockTestResult(ctrl)
-		facts := []testapi.TestFact{
-			{
-				TotalDependencyCount: 42,
-				Type:                 testapi.DependencyCountFactTypeDependencyCountFact,
-			},
-		}
-		mockResult.EXPECT().GetTestFacts().Return(&facts)
+		mockResult.EXPECT().GetMetadataValue(testapi.MetadataKeyDependencyCount).Return(42)
 
 		count := ostest.GetDependencyCountFromTestFacts(mockResult)
 		assert.Equal(t, 42, count)


### PR DESCRIPTION
## What does this PR do?

Uses `testapi.MetadataKey*` and `GetMetadataValue` for project ID and dependency count; `SetMetadata` uses the same constants. Updates gomock tests to expect `GetMetadataValue` / `ShallowMetadataCopy` instead of removed `TestResult` getters.

## Where should the reviewer start?

- `internal/commands/ostest/test_execution.go`
- `internal/commands/ostest/*_test.go`

## How should this be manually tested?

`go test ./...`

## Dependency / merge order

Requires **go-application-framework** release (or `replace`) containing CLI-1301. Remove or replace `go.mod` `replace` with a published GAF version before merge if your process forbids local replaces.

## Risk assessment

**Low–Medium** — behavior unchanged if metadata is populated by GAF as before.

## Tickets

[CLI-1301](https://snyksec.atlassian.net/browse/CLI-1301)

[CLI-1301]: https://snyksec.atlassian.net/browse/CLI-1301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ