### PR TITLE
fix: depgraph handling in the dragonfly flow

### DIFF
--- a/internal/commands/osmonitor/dfly_depgraph_flow_test.go
+++ b/internal/commands/osmonitor/dfly_depgraph_flow_test.go
@@ -131,6 +131,7 @@ func Test_OSWorkflow_DflyFFEnabled_UsesDflyFlow(t *testing.T) {
 	cfg := mockIctx.GetConfiguration()
 	cfg.Set(constants.FeatureFlagDlfyCLIRollout, true)
 	cfg.Set(configuration.INPUT_DIRECTORY, t.TempDir())
+	cfg.Set(configuration.RAW_CMD_ARGS, "monitor "+t.TempDir())
 
 	// The dfly flow will fail trying to resolve dep graphs since there's no real project,
 	// but that's expected -- we're verifying routing, not the full flow.

--- a/internal/common/depgraph_resolver.go
+++ b/internal/common/depgraph_resolver.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/orchestrator"
@@ -57,6 +58,9 @@ func (dr *depgraphResolver) GetDepGraphsWithIdentity(ictx workflow.InvocationCon
 	logger := ictx.GetEnhancedLogger()
 
 	rawFlags := config.GetStringSlice(configuration.RAW_CMD_ARGS)
+	// For monitor we need to change the passed command to "test", otherwise the legacy CLI will
+	// attempt to monitor the depgraphs itself
+	rawFlags[0] = strings.Replace(rawFlags[0], "monitor", "test", 1)
 	opts, err := ecosystems.NewPluginOptionsFromRawFlags(rawFlags)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert raw flags to options: %w", err)

--- a/internal/common/dfly_depgraph_flow.go
+++ b/internal/common/dfly_depgraph_flow.go
@@ -82,6 +82,12 @@ func RunDflyDepgraphFlow(
 		return nil, nil, fmt.Errorf("no testable projects found")
 	}
 
+	if override := cfg.GetString(flags.FlagProjectName); override != "" {
+		for i := range depGraphs {
+			depGraphs[i].Identity.Name = override
+		}
+	}
+
 	tmpRootDir, paths, err := createDepgraphTmpFiles(depGraphs)
 	defer func() {
 		tmpDirRmErr := os.RemoveAll(tmpRootDir)
@@ -102,12 +108,6 @@ func RunDflyDepgraphFlow(
 	uploadRes, err := clients.FileUploadClient.CreateRevisionFromChan(ctx, pathsChan, tmpRootDir)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to upload dependency graphs: %w", err)
-	}
-
-	if override := cfg.GetString(flags.FlagProjectName); override != "" {
-		for i := range depGraphs {
-			depGraphs[i].Identity.Name = override
-		}
 	}
 
 	scmInfo := ResolveScmInfo(inputDir, cfg.GetString(flags.FlagRemoteRepoURL), logger)


### PR DESCRIPTION
# What this does?
* replaces `monitor` to `test` in the raw cmd flags we pass to the interface, to avoid the legacy CLI monitoring the graphs
* ensures the project name override in depgraphs is applied before uploading them