### PR TITLE
refactor: migrate ecosystems logic from os-flows to dep-graph

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,4 +117,4 @@ require (
 )
 
 // replace github.com/snyk/go-application-framework => ../go-application-framework
-// replace github.com/snyk/cli-extension-dep-graph => ../cli-extension-dep-graph
+replace github.com/snyk/cli-extension-dep-graph => ../cli-extension-dep-graph

--- a/internal/commands/ostest/routing.go
+++ b/internal/commands/ostest/routing.go
@@ -13,7 +13,6 @@ import (
 	"github.com/snyk/cli-extension-os-flows/internal/constants"
 	internalErrors "github.com/snyk/cli-extension-os-flows/internal/errors"
 	"github.com/snyk/cli-extension-os-flows/internal/settings"
-	"github.com/snyk/cli-extension-os-flows/internal/util"
 	"github.com/snyk/cli-extension-os-flows/pkg/flags"
 )
 
@@ -123,6 +122,7 @@ type FlowConfig struct {
 	FFRiskScoreInCLI                bool
 	FFUseTestShimForOSCliTest       bool
 	FFUseUnifiedTestAPIForOSCliTest bool
+	FFUvCLI                         bool
 	RiskScoreFFsEnabled             bool
 	RiskScoreThreshold              int
 	RiskScoreTest                   bool
@@ -160,6 +160,7 @@ func ParseFlowConfig(cfg configuration.Configuration) (*FlowConfig, error) {
 	riskScoreThreshold := cfg.GetInt(flags.FlagRiskScoreThreshold)
 	riskScoreTest := riskScoreFFsEnabled || riskScoreThreshold != -1
 	ffDflyRollout := cfg.GetBool(constants.FeatureFlagDlfyCLIRollout)
+	ffUvCLI := cfg.GetBool(constants.FeatureFlagUvCLI)
 
 	reachability := cfg.GetBool(flags.FlagReachability)
 	sbom := cfg.GetString(flags.FlagSBOM)
@@ -200,6 +201,7 @@ func ParseFlowConfig(cfg configuration.Configuration) (*FlowConfig, error) {
 		FFRiskScoreInCLI:                ffRiskScoreInCLI,
 		FFUseTestShimForOSCliTest:       ffUseTestShimForOSCliTest,
 		FFUseUnifiedTestAPIForOSCliTest: ffUseUnifiedTestAPIForOSCliTest,
+		FFUvCLI:                         ffUvCLI,
 		RiskScoreFFsEnabled:             riskScoreFFsEnabled,
 		RiskScoreThreshold:              riskScoreThreshold,
 		RiskScoreTest:                   riskScoreTest,
@@ -220,22 +222,9 @@ func ParseFlowConfig(cfg configuration.Configuration) (*FlowConfig, error) {
 func ShouldUseLegacyFlow(ctx context.Context, fc *FlowConfig, inputDirs []string) (bool, error) {
 	errFactory := cmdctx.ErrorFactory(ctx)
 	logger := cmdctx.Logger(ctx)
-	cfg := cmdctx.Config(ctx)
 
 	if err := validateLegacyCLIOptions(fc, errFactory); err != nil {
 		return false, err
-	}
-
-	// Check if uv support should trigger, first check if uv.lock exists and then check if the FF is enabled.
-	uvLockExists := util.HasUvLockFileInAnyDir(inputDirs, fc.FileFlag, fc.AllProjects, logger)
-	var uvSupportWithLockFile bool
-	if uvLockExists {
-		ffUvCLI := cfg.GetBool(constants.FeatureFlagUvCLI)
-		uvSupportWithLockFile = ffUvCLI
-		logger.Debug().Msgf("uv.lock found, uv feature flag from registry: %t", ffUvCLI)
-	} else {
-		uvSupportWithLockFile = false
-		logger.Debug().Msg("uv.lock not found, skipping uv feature flag check")
 	}
 
 	hasNewFeatures := fc.FFDflyRollout ||
@@ -243,19 +232,19 @@ func ShouldUseLegacyFlow(ctx context.Context, fc *FlowConfig, inputDirs []string
 		fc.Reachability ||
 		fc.SBOM != "" ||
 		fc.ReachabilityFilter != "" ||
-		uvSupportWithLockFile ||
+		fc.FFUvCLI ||
 		fc.FFUseTestShimForOSCliTest ||
 		fc.FFUseUnifiedTestAPIForOSCliTest
 	useLegacy := fc.ForceLegacyTest || fc.RequiresLegacy || !hasNewFeatures
 
 	logger.Debug().Msgf(
 		"Using legacy flow: %t. Legacy CLI Env var: %t. SBOM Reachability Test: %t."+
-			"Risk Score Test: %t. Experimental uv Support: %t. Test Shim FF: %t. Dfly Rollout: %t. Unified Test API FF: %t.",
+			"Risk Score Test: %t. uv FF: %t. Test Shim FF: %t. Dfly Rollout: %t. Unified Test API FF: %t.",
 		useLegacy,
 		fc.ForceLegacyTest,
 		fc.SBOMReachabilityTest,
 		fc.RiskScoreTest,
-		uvSupportWithLockFile,
+		fc.FFUvCLI,
 		fc.FFUseTestShimForOSCliTest,
 		fc.FFDflyRollout,
 		fc.FFUseUnifiedTestAPIForOSCliTest,

--- a/internal/commands/ostest/routing_test.go
+++ b/internal/commands/ostest/routing_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/snyk/cli-extension-os-flows/internal/commands/ostest"
 	"github.com/snyk/cli-extension-os-flows/internal/constants"
 	"github.com/snyk/cli-extension-os-flows/internal/settings"
-	"github.com/snyk/cli-extension-os-flows/internal/util"
 )
 
 var (
@@ -255,14 +254,10 @@ func Test_ShouldUseLegacyFlow(t *testing.T) {
 		assert.Equal(t, "The argument 'lodash@1.2.3' cannot be combined with flags --reachability.", catalogErr.Detail)
 	})
 
-	t.Run("when uv support is enabled with uv.lock file present and feature flag set", func(t *testing.T) {
+	t.Run("when uv feature flag is enabled should use new flow", func(t *testing.T) {
 		t.Parallel()
 		cfg := defaultConfig.Clone()
 		cfg.Set(constants.FeatureFlagUvCLI, true)
-
-		// Create temp directory with uv.lock file
-		tempDir := util.CreateTempDirWithUvLock(t)
-		cfg.Set(configuration.INPUT_DIRECTORY, []string{tempDir})
 
 		ctx := t.Context()
 		ctx = cmdctx.WithConfig(ctx, cfg)
@@ -271,43 +266,17 @@ func Test_ShouldUseLegacyFlow(t *testing.T) {
 
 		flowCfg, err := ostest.ParseFlowConfig(cfg)
 		require.NoError(t, err)
-		useLegacy, err := ostest.ShouldUseLegacyFlow(ctx, flowCfg, []string{tempDir})
+		useLegacy, err := ostest.ShouldUseLegacyFlow(ctx, flowCfg, []string{"."})
 		require.NoError(t, err)
 
-		assert.False(t, useLegacy, "should use new flow when uv feature flag is enabled and uv.lock exists")
+		assert.False(t, useLegacy, "should use new flow when uv feature flag is enabled")
 	})
 
-	t.Run("when uv feature flag is enabled but uv.lock file is missing", func(t *testing.T) {
-		t.Parallel()
-		cfg := defaultConfig.Clone()
-		cfg.Set(constants.FeatureFlagUvCLI, true)
-
-		// Create temp directory without uv.lock file
-		tempDir := t.TempDir()
-		cfg.Set(configuration.INPUT_DIRECTORY, []string{tempDir})
-
-		ctx := t.Context()
-		ctx = cmdctx.WithConfig(ctx, cfg)
-		ctx = cmdctx.WithLogger(ctx, &nopLogger)
-		ctx = cmdctx.WithErrorFactory(ctx, errFactory)
-
-		flowCfg, err := ostest.ParseFlowConfig(cfg)
-		require.NoError(t, err)
-		useLegacy, err := ostest.ShouldUseLegacyFlow(ctx, flowCfg, []string{tempDir})
-		require.NoError(t, err)
-
-		assert.True(t, useLegacy, "should use legacy flow when uv feature flag is enabled but uv.lock is missing")
-	})
-
-	t.Run("when uv feature flag is disabled even with uv.lock present", func(t *testing.T) {
+	t.Run("when uv feature flag is disabled should use legacy flow", func(t *testing.T) {
 		t.Parallel()
 		cfg := defaultConfig.Clone()
 		cfg.Set(constants.FeatureFlagUvCLI, false)
 
-		// Create temp directory with uv.lock file
-		tempDir := util.CreateTempDirWithUvLock(t)
-		cfg.Set(configuration.INPUT_DIRECTORY, []string{tempDir})
-
 		ctx := t.Context()
 		ctx = cmdctx.WithConfig(ctx, cfg)
 		ctx = cmdctx.WithLogger(ctx, &nopLogger)
@@ -315,10 +284,10 @@ func Test_ShouldUseLegacyFlow(t *testing.T) {
 
 		flowCfg, err := ostest.ParseFlowConfig(cfg)
 		require.NoError(t, err)
-		useLegacy, err := ostest.ShouldUseLegacyFlow(ctx, flowCfg, []string{tempDir})
+		useLegacy, err := ostest.ShouldUseLegacyFlow(ctx, flowCfg, []string{"."})
 		require.NoError(t, err)
 
-		assert.True(t, useLegacy, "should use legacy flow when uv support is disabled regardless of uv.lock presence")
+		assert.True(t, useLegacy, "should use legacy flow when uv feature flag is disabled")
 	})
 }
 

--- a/internal/commands/ostest/sbom_resolution_integration_test.go
+++ b/internal/commands/ostest/sbom_resolution_integration_test.go
@@ -111,11 +111,7 @@ func setupSBOMResolutionIntegrationTest(
 
 	mockEngine.EXPECT().
 		InvokeWithConfig(common.DepGraphWorkflowID, gomock.Any()).
-		DoAndReturn(func(_ workflow.Identifier, cfg configuration.Configuration) ([]workflow.Data, error) {
-			// Verify that use-sbom-resolution flag is set
-			assert.True(t, cfg.GetBool("use-sbom-resolution"), "use-sbom-resolution flag should be set when uv support is enabled")
-			return []workflow.Data{depGraphData}, nil
-		}).
+		Return([]workflow.Data{depGraphData}, nil).
 		Times(1)
 
 	mockTestClient.EXPECT().

--- a/internal/commands/ostest/workflow_test.go
+++ b/internal/commands/ostest/workflow_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/snyk/cli-extension-os-flows/internal/errors"
 	"github.com/snyk/cli-extension-os-flows/internal/legacy/definitions"
 	"github.com/snyk/cli-extension-os-flows/internal/outputworkflow"
-	"github.com/snyk/cli-extension-os-flows/internal/util"
 )
 
 var (
@@ -290,43 +289,15 @@ func TestOSWorkflow_FlagCombinations(t *testing.T) {
 			expectedError: "Reachability settings not enabled",
 		},
 		{
-			name: "uv test flow enabled with uv.lock file should use depgraph workflow with SBOM resolution",
+			name: "uv FF enabled should route to depgraph workflow",
 			setup: func(config configuration.Configuration, mockEngine *mocks.MockEngine) {
-				// Create temp directory with uv.lock file
-				tempDir := util.CreateTempDirWithUvLock(t)
-				config.Set(configuration.INPUT_DIRECTORY, []string{tempDir})
 				config.Set(constants.FeatureFlagUvCLI, true)
 				mockEngine.EXPECT().
 					InvokeWithConfig(common.DepGraphWorkflowID, gomock.Any()).
-					DoAndReturn(func(_ workflow.Identifier, cfg configuration.Configuration) ([]workflow.Data, error) {
-						// Verify that use-sbom-resolution flag is set
-						if !cfg.GetBool("use-sbom-resolution") {
-							return nil, fmt.Errorf("Expected use-sbom-resolution flag to be set")
-						}
-						return nil, assert.AnError
-					}).
+					Return(nil, assert.AnError).
 					Times(1)
 			},
 			expectedError: "failed to get dependency graph",
-		},
-		{
-			name: "uv test flow enabled without uv.lock file should fall back to legacy flow",
-			setup: func(config configuration.Configuration, mockEngine *mocks.MockEngine) {
-				// Create temp directory without uv.lock file
-				tempDir := t.TempDir()
-				config.Set(configuration.INPUT_DIRECTORY, []string{tempDir})
-				config.Set(constants.FeatureFlagUvCLI, true)
-
-				// Should route directly to legacy flow (not depgraph workflow)
-				mockEngine.EXPECT().
-					InvokeWithConfig(common.DepGraphWorkflowID, gomock.Any()).
-					Times(0)
-				mockEngine.EXPECT().
-					InvokeWithConfig(legacyWorkflowID, gomock.Any()).
-					Return([]workflow.Data{}, nil).
-					Times(1)
-			},
-			expectedError: "", // No error, should succeed via legacy flow
 		},
 		{
 			name: "uv test flow disabled should use legacy flow",
@@ -376,15 +347,10 @@ func TestOSWorkflow_FlagCombinations(t *testing.T) {
 			expectedError: "failed to get dependency graph",
 		},
 		{
-			name: "useTestShimForOSCliTest FF disabled WITH uv support active, expects depgraph workflow (new flow)",
+			name: "useTestShimForOSCliTest FF disabled WITH uv FF active, expects depgraph workflow (new flow)",
 			setup: func(config configuration.Configuration, mockEngine *mocks.MockEngine) {
-				// Create temp directory with uv.lock file
-				tempDir := util.CreateTempDirWithUvLock(t)
-				config.Set(configuration.INPUT_DIRECTORY, []string{tempDir})
 				config.Set(constants.FeatureFlagUvCLI, true)
-				// Explicitly disable the test shim FF
 				config.Set(constants.FeatureFlagUseTestShimForOSCliTest, false)
-				// uv support should override, still use new flow
 				mockEngine.EXPECT().
 					InvokeWithConfig(common.DepGraphWorkflowID, gomock.Any()).
 					Return(nil, assert.AnError).

--- a/internal/common/depgraph.go
+++ b/internal/common/depgraph.go
@@ -5,12 +5,9 @@ import (
 	"fmt"
 
 	"github.com/rs/zerolog"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/orchestrator"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
-	"github.com/snyk/cli-extension-os-flows/internal/constants"
 	"github.com/snyk/cli-extension-os-flows/internal/errors"
 	"github.com/snyk/cli-extension-os-flows/internal/util"
 	"github.com/snyk/cli-extension-os-flows/pkg/flags"
@@ -40,44 +37,19 @@ type RawDepGraphWithMeta struct {
 }
 
 // GetDepGraph retrieves the dependency graph for the given invocation context.
+// All resolution strategy decisions (legacy CLI, SBOM, orchestrator) are handled
+// by the dep-graph extension's callback based on feature flags and lockfile detection.
 func GetDepGraph(ictx workflow.InvocationContext, inputDir string) ([]RawDepGraphWithMeta, error) {
 	engine := ictx.GetEngine()
 	config := ictx.GetConfiguration()
 	logger := ictx.GetEnhancedLogger()
 	errFactory := errors.NewErrorFactory(logger)
 
-	// Branch off to get dep-graphs plus project identities from the orchestrator.
-	// TODO: move this FF check and branching logic into the dep-graph extension. The main workflow should be the canonical entrypoint for all OS flows.
-	if config.GetBool(constants.FeatureFlagUseUnifiedTestAPIForOSCliTest) {
-		opts, err := ecosystems.NewPluginOptionsFromRawFlags(config.GetStringSlice(configuration.RAW_CMD_ARGS))
-		if err != nil {
-			return nil, errFactory.NewDepGraphWorkflowError(err)
-		}
-		return getDepgraphsFromOrchestrator(ictx, inputDir, opts)
-	}
-
 	depGraphConfig := config.Clone()
-	allProjects := config.GetBool(flags.FlagAllProjects)
-	fileFlag := config.GetString(flags.FlagFile)
-
-	// Check if uv support should trigger, first check if uv.lock exists and then check if the FF is enabled.
-	// TODO: move this FF check and branching logic into the dep-graph extension.
-	uvLockExists := util.HasUvLockFile(inputDir, fileFlag, allProjects, logger)
-	if uvLockExists {
-		ffUvCLI := config.GetBool(constants.FeatureFlagUvCLI)
-		if ffUvCLI {
-			logger.Info().Msg("uv support enabled and uv.lock found, using SBOM resolution in depgraph workflow")
-			depGraphConfig.Set("use-sbom-resolution", true)
-		} else {
-			logger.Info().Msg("uv.lock found but uv feature flag disabled, using standard depgraph workflow")
-		}
-	} else {
-		logger.Info().Msg("Invoking depgraph workflow")
-	}
-
-	// Overriding the INPUT_DIRECTORY flag which the depgraph workflow will use to extract the depgraphs.
 	depGraphConfig.Set(configuration.INPUT_DIRECTORY, inputDir)
 	depGraphConfig.Set(ConfigFlagEffectiveDepGraphs, true)
+
+	logger.Info().Msg("Invoking depgraph workflow")
 	depGraphsData, err := engine.InvokeWithConfig(DepGraphWorkflowID, depGraphConfig)
 	if err != nil {
 		return nil, errFactory.NewDepGraphWorkflowError(err)
@@ -88,6 +60,8 @@ func GetDepGraph(ictx workflow.InvocationContext, inputDir string) ([]RawDepGrap
 	if err != nil {
 		return nil, errFactory.NewDepGraphWorkflowError(err)
 	}
+
+	addSCMContext(depGraphs, inputDir, config.GetString(flags.FlagRemoteRepoURL), logger)
 
 	return depGraphs, nil
 }
@@ -148,54 +122,29 @@ func optionalMetaDataBytes(data workflow.Data, key string) []byte {
 	return []byte(*strValue)
 }
 
-func getDepgraphsFromOrchestrator(ictx workflow.InvocationContext, inputDir string, opts *ecosystems.SCAPluginOptions) ([]RawDepGraphWithMeta, error) {
-	results, err := orchestrator.ResolveDepgraphs(ictx, inputDir, *opts)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve depgraphs through ecosystems orchestrator: %w", err)
-	}
+// addSCMContext resolves SCM metadata (remote URL, branch) and attaches it
+// to any dep-graph results that don't already carry a target.
+func addSCMContext(depGraphs []RawDepGraphWithMeta, inputDir, remoteRepoURL string, logger *zerolog.Logger) {
+	var target []byte
+	resolved := false
 
-	logger := ictx.GetEnhancedLogger()
-	config := ictx.GetConfiguration()
-	target := resolveTarget(inputDir, config.GetString(flags.FlagRemoteRepoURL), logger)
-
-	rawDepGraphs := make([]RawDepGraphWithMeta, 0)
-	for result := range results {
-		dg, err := mapToRawDepGraphWithMeta(&result, target)
-		if err != nil {
-			return nil, err
+	for i := range depGraphs {
+		if depGraphs[i].Target != nil {
+			continue
 		}
-		rawDepGraphs = append(rawDepGraphs, *dg)
+		if !resolved {
+			scm := ResolveScmInfo(inputDir, remoteRepoURL, logger)
+			if scm == nil {
+				return
+			}
+			var err error
+			target, err = json.Marshal(scm)
+			if err != nil {
+				logger.Warn().Err(err).Msg("Failed to marshal SCM info, proceeding without target context")
+				return
+			}
+			resolved = true
+		}
+		depGraphs[i].Target = target
 	}
-	return rawDepGraphs, nil
-}
-
-func resolveTarget(inputDir, remoteRepoURL string, logger *zerolog.Logger) []byte {
-	scmInfo := ResolveScmInfo(inputDir, remoteRepoURL, logger)
-	if scmInfo == nil {
-		return nil
-	}
-	target, err := json.Marshal(scmInfo)
-	if err != nil {
-		logger.Warn().Err(err).Msg("Failed to marshal SCM info, proceeding without SCM context")
-	}
-	return target
-}
-
-func mapToRawDepGraphWithMeta(result *ecosystems.SCAResult, target []byte) (*RawDepGraphWithMeta, error) {
-	if result.Error != nil {
-		return nil, fmt.Errorf("failed to resolve depgraph for %s: %w",
-			result.ProjectDescriptor.GetTargetFile(), result.Error)
-	}
-
-	payload, err := json.Marshal(result.DepGraph)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal depgraph: %w", err)
-	}
-
-	return &RawDepGraphWithMeta{
-		Payload:              payload,
-		NormalisedTargetFile: util.DefaultValue(result.ProjectDescriptor.Identity.TargetFile, ""),
-		TargetFileFromPlugin: result.ProjectDescriptor.Identity.TargetFile,
-		Target:               target,
-	}, nil
 }

--- a/internal/common/depgraph_internal_test.go
+++ b/internal/common/depgraph_internal_test.go
@@ -2,88 +2,184 @@ package common
 
 import (
 	"encoding/json"
-	"errors"
+	"os"
 	"testing"
+	"time"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
-	"github.com/snyk/dep-graph/go/pkg/depgraph"
+	gogit "github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/snyk/cli-extension-os-flows/internal/util"
 )
 
-func TestMapToRawDepGraphWithMeta_Success(t *testing.T) {
-	dg := &depgraph.DepGraph{
-		SchemaVersion: "1.2.0",
-		PkgManager:    depgraph.PkgManager{Name: "npm"},
-		Pkgs: []depgraph.Pkg{
-			{ID: "proj@1.0.0", Info: depgraph.PkgInfo{Name: "proj", Version: "1.0.0"}},
-		},
-		Graph: depgraph.Graph{RootNodeID: "root"},
-	}
-	target := []byte(`{"remoteUrl":"https://github.com/acme/repo.git","branch":"main"}`)
+func TestAddSCMContext(t *testing.T) {
+	t.Parallel()
+	nop := zerolog.Nop()
 
-	result := &ecosystems.SCAResult{
-		DepGraph: dg,
-		ProjectDescriptor: identity.ProjectDescriptor{
-			Identity: identity.ProjectIdentity{
-				TargetFile: util.Ptr("package.json"),
-			},
-		},
-	}
+	t.Run("attaches SCM target to results without existing target", func(t *testing.T) {
+		t.Parallel()
+		dir := initTestGitRepo(t, "https://github.com/acme/repo.git")
 
-	raw, err := mapToRawDepGraphWithMeta(result, target)
+		depGraphs := []RawDepGraphWithMeta{
+			{Payload: []byte(`{"pkgManager":"npm"}`), NormalisedTargetFile: "package.json"},
+		}
 
-	require.NoError(t, err)
+		addSCMContext(depGraphs, dir, "", &nop)
 
-	var unmarshaled depgraph.DepGraph
-	require.NoError(t, json.Unmarshal(raw.Payload, &unmarshaled))
-	assert.Equal(t, "npm", unmarshaled.PkgManager.Name)
+		require.NotNil(t, depGraphs[0].Target)
+		var scm ScmInfo
+		require.NoError(t, json.Unmarshal(depGraphs[0].Target, &scm))
+		assert.Equal(t, "https://github.com/acme/repo.git", scm.RemoteURL)
+		assert.Equal(t, "main", scm.Branch)
+	})
 
-	assert.Equal(t, "package.json", raw.NormalisedTargetFile)
-	require.NotNil(t, raw.TargetFileFromPlugin)
-	assert.Equal(t, "package.json", *raw.TargetFileFromPlugin)
-	assert.Equal(t, target, raw.Target)
+	t.Run("leaves target nil when not in a git repo", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		depGraphs := []RawDepGraphWithMeta{
+			{Payload: []byte(`{}`), NormalisedTargetFile: "pom.xml"},
+		}
+
+		addSCMContext(depGraphs, dir, "", &nop)
+
+		assert.Nil(t, depGraphs[0].Target)
+	})
+
+	t.Run("does not overwrite existing target", func(t *testing.T) {
+		t.Parallel()
+		dir := initTestGitRepo(t, "https://github.com/acme/repo.git")
+		existingTarget := []byte(`{"remoteUrl":"https://existing.example.com","branch":"develop"}`)
+
+		depGraphs := []RawDepGraphWithMeta{
+			{Payload: []byte(`{}`), NormalisedTargetFile: "package.json", Target: existingTarget},
+		}
+
+		addSCMContext(depGraphs, dir, "", &nop)
+
+		assert.Equal(t, existingTarget, depGraphs[0].Target)
+	})
+
+	t.Run("fills only results missing a target in a mixed set", func(t *testing.T) {
+		t.Parallel()
+		dir := initTestGitRepo(t, "https://github.com/acme/mixed.git")
+		existingTarget := []byte(`{"remoteUrl":"https://pre-existing.example.com","branch":"feat"}`)
+
+		depGraphs := []RawDepGraphWithMeta{
+			{Payload: []byte(`{}`), NormalisedTargetFile: "package.json", Target: existingTarget},
+			{Payload: []byte(`{}`), NormalisedTargetFile: "pom.xml"},
+			{Payload: []byte(`{}`), NormalisedTargetFile: "go.mod"},
+		}
+
+		addSCMContext(depGraphs, dir, "", &nop)
+
+		assert.Equal(t, existingTarget, depGraphs[0].Target, "pre-existing target should not be overwritten")
+
+		require.NotNil(t, depGraphs[1].Target)
+		require.NotNil(t, depGraphs[2].Target)
+		var scm ScmInfo
+		require.NoError(t, json.Unmarshal(depGraphs[1].Target, &scm))
+		assert.Equal(t, "https://github.com/acme/mixed.git", scm.RemoteURL)
+
+		assert.Equal(t, depGraphs[1].Target, depGraphs[2].Target, "both filled results should share the same resolved target")
+	})
+
+	t.Run("uses remote-repo-url override instead of git detection", func(t *testing.T) {
+		t.Parallel()
+		dir := initTestGitRepo(t, "https://github.com/acme/repo.git")
+
+		depGraphs := []RawDepGraphWithMeta{
+			{Payload: []byte(`{}`), NormalisedTargetFile: "package.json"},
+		}
+
+		addSCMContext(depGraphs, dir, "https://override.example.com/repo.git", &nop)
+
+		require.NotNil(t, depGraphs[0].Target)
+		var scm ScmInfo
+		require.NoError(t, json.Unmarshal(depGraphs[0].Target, &scm))
+		assert.Equal(t, "https://override.example.com/repo.git", scm.RemoteURL)
+	})
+
+	t.Run("handles empty results slice without error", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		depGraphs := []RawDepGraphWithMeta{}
+
+		addSCMContext(depGraphs, dir, "", &nop)
+
+		assert.Empty(t, depGraphs)
+	})
+
+	t.Run("skips all results when every result already has a target", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		target1 := []byte(`{"remoteUrl":"a"}`)
+		target2 := []byte(`{"remoteUrl":"b"}`)
+
+		depGraphs := []RawDepGraphWithMeta{
+			{Payload: []byte(`{}`), Target: target1},
+			{Payload: []byte(`{}`), Target: target2},
+		}
+
+		addSCMContext(depGraphs, dir, "", &nop)
+
+		assert.Equal(t, target1, depGraphs[0].Target)
+		assert.Equal(t, target2, depGraphs[1].Target)
+	})
+
+	t.Run("attaches target to multiple results from non-git dir with override", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		depGraphs := []RawDepGraphWithMeta{
+			{Payload: []byte(`{}`), NormalisedTargetFile: "package.json"},
+			{Payload: []byte(`{}`), NormalisedTargetFile: "pom.xml"},
+		}
+
+		addSCMContext(depGraphs, dir, "https://ci.example.com/repo.git", &nop)
+
+		for i, dg := range depGraphs {
+			require.NotNil(t, dg.Target, "result %d should have target", i)
+			var scm ScmInfo
+			require.NoError(t, json.Unmarshal(dg.Target, &scm))
+			assert.Equal(t, "https://ci.example.com/repo.git", scm.RemoteURL)
+			assert.Empty(t, scm.Branch, "branch should be empty for non-git dir")
+		}
+	})
 }
 
-func TestMapToRawDepGraphWithMeta_NilTargetFile(t *testing.T) {
-	dg := &depgraph.DepGraph{
-		SchemaVersion: "1.2.0",
-		PkgManager:    depgraph.PkgManager{Name: "maven"},
-	}
+func initTestGitRepo(t *testing.T, remoteURL string) string {
+	t.Helper()
+	dir := t.TempDir()
 
-	result := &ecosystems.SCAResult{
-		DepGraph: dg,
-		ProjectDescriptor: identity.ProjectDescriptor{
-			Identity: identity.ProjectIdentity{
-				TargetFile: nil,
-			},
+	repo, err := gogit.PlainInitWithOptions(dir, &gogit.PlainInitOptions{
+		InitOptions: gogit.InitOptions{
+			DefaultBranch: plumbing.NewBranchReferenceName("main"),
 		},
-	}
-
-	raw, err := mapToRawDepGraphWithMeta(result, nil)
-
+	})
 	require.NoError(t, err)
-	assert.Equal(t, "", raw.NormalisedTargetFile)
-	assert.Nil(t, raw.TargetFileFromPlugin)
-	assert.Nil(t, raw.Target)
-}
 
-func TestMapToRawDepGraphWithMeta_ResultError(t *testing.T) {
-	result := &ecosystems.SCAResult{
-		ProjectDescriptor: identity.ProjectDescriptor{
-			Identity: identity.ProjectIdentity{
-				TargetFile: util.Ptr("pom.xml"),
-			},
-		},
-		Error: errors.New("resolution failed"),
-	}
+	_, err = repo.CreateRemote(&gitconfig.RemoteConfig{
+		Name: "origin",
+		URLs: []string{remoteURL},
+	})
+	require.NoError(t, err)
 
-	_, err := mapToRawDepGraphWithMeta(result, nil)
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	f, err := os.CreateTemp(dir, "init")
+	require.NoError(t, err)
+	f.Close()
+	_, err = wt.Add(f.Name()[len(dir)+1:])
+	require.NoError(t, err)
+	_, err = wt.Commit("init", &gogit.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
+	})
+	require.NoError(t, err)
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to resolve depgraph for pom.xml")
-	assert.ErrorContains(t, err, "resolution failed")
+	return dir
 }


### PR DESCRIPTION
<img src="http://textfiles.com/underconstruction/AtAthensAtrium4933underconstruction1.gif" />



This is a follow up to https://github.com/snyk/cli-extension-dep-graph/pull/165.

It's still WIP, just a preview of the changes to come.