### PR TITLE
fix: register remote repo url flag

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -154,6 +154,7 @@ func OSTestFlagSet() *pflag.FlagSet {
 		"to the name of files inside a project along with any desired separators.")
 	flagSet.Bool(FlagDotnetRuntimeResolution, false, "You must use this option when you test .NET projects using Runtime Resolution Scanning.")
 	flagSet.String(FlagDotnetTargetFramework, "", "Specify the target framework for .NET projects.")
+	flagSet.String(FlagRemoteRepoURL, "", "Set or override the remote URL for the repository.")
 
 	return flagSet
 }

--- a/pkg/flags/flags_test.go
+++ b/pkg/flags/flags_test.go
@@ -68,3 +68,31 @@ func TestReachabilityFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoteRepoURLFlag(t *testing.T) {
+	flagSets := []struct {
+		name     string
+		createFn func() *pflag.FlagSet
+	}{
+		{
+			name:     "OSTestFlagSet",
+			createFn: flags.OSTestFlagSet,
+		},
+		{
+			name:     "OSMonitorFlagSet",
+			createFn: flags.OSMonitorFlagSet,
+		},
+	}
+
+	for _, fs := range flagSets {
+		t.Run(fs.name, func(t *testing.T) {
+			flagSet := fs.createFn()
+			err := flagSet.Parse([]string{"--remote-repo-url=https://github.com/example/repo.git"})
+			require.NoError(t, err, "flag parsing should not fail")
+
+			value, err := flagSet.GetString(flags.FlagRemoteRepoURL)
+			require.NoError(t, err, "getting flag value should not fail")
+			assert.Equal(t, "https://github.com/example/repo.git", value)
+		})
+	}
+}


### PR DESCRIPTION
`FlagRemoteRepoURL` is registered in `OSMonitorFlagSet()` but is missing from `OSTestFlagSet()` - adding to the latter. This fixes a problem [reported here](https://snyk.slack.com/archives/C0ANFFNFTV0/p1777386036500609).