### PR TITLE
chore: use given context from invocationContext

### DIFF
--- a/internal/commands/osmonitor/workflow.go
+++ b/internal/commands/osmonitor/workflow.go
@@ -162,7 +162,7 @@ func OSWorkflow(
 	ictx workflow.InvocationContext,
 	_ []workflow.Data,
 ) ([]workflow.Data, error) {
-	ctx := context.Background()
+	ctx := ictx.Context()
 	cfg := ictx.GetConfiguration()
 	logger := ictx.GetEnhancedLogger()
 	errFactory := errors.NewErrorFactory(logger)

--- a/internal/commands/ostest/depgraph_flow.go
+++ b/internal/commands/ostest/depgraph_flow.go
@@ -286,7 +286,6 @@ func handleOutput(
 	var finalOutput []workflow.Data
 	if wantsHumanReadable {
 		outputDestination := outputworkflow.NewOutputDestination()
-		//nolint:contextcheck // The outputworkflow.EntryPoint call chain is not context-aware.
 		remainingData, err := outputworkflow.EntryPoint(ictx, allOutputData, outputDestination)
 		if err != nil {
 			return nil, fmt.Errorf("failed to process output workflow: %w", err)

--- a/internal/commands/ostest/workflow.go
+++ b/internal/commands/ostest/workflow.go
@@ -100,7 +100,7 @@ func showEarlyAccessBanner(ictx workflow.InvocationContext) {
 
 // initializeWorkflowContext creates and configures the context for the workflow.
 func initializeWorkflowContext(ictx workflow.InvocationContext) context.Context {
-	ctx := context.Background()
+	ctx := ictx.Context()
 	cfg := ictx.GetConfiguration()
 	logger := ictx.GetEnhancedLogger()
 	errFactory := errors.NewErrorFactory(logger)

--- a/internal/commands/ostest/workflow_test.go
+++ b/internal/commands/ostest/workflow_test.go
@@ -1,6 +1,7 @@
 package ostest_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -498,6 +499,7 @@ func createMockInvocationCtxWithURL(t *testing.T, ctrl *gomock.Controller, engin
 	mockNetwork.EXPECT().GetHttpClient().Return(&http.Client{}).AnyTimes()
 	icontext.EXPECT().GetNetworkAccess().Return(mockNetwork).AnyTimes()
 	icontext.EXPECT().GetAnalytics().Return(analytics.New()).AnyTimes()
+	icontext.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	return icontext
 }

--- a/internal/outputworkflow/findings_model_tools.go
+++ b/internal/outputworkflow/findings_model_tools.go
@@ -1,7 +1,6 @@
 package outputworkflow
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"strings"
@@ -231,7 +230,7 @@ func HandleContentTypeUnifiedModel(input []workflow.Data, invocation workflow.In
 	debugLogger.Info().Msgf("Thread count: %d", threadCount)
 
 	// iterate over all writers and render for each of them
-	ctx := context.Background()
+	ctx := invocation.Context()
 	availableThreads := semaphore.NewWeighted(threadCount)
 	for k, v := range writerMap {
 		err = availableThreads.Acquire(ctx, 1)

--- a/internal/outputworkflow/output_workflow_test.go
+++ b/internal/outputworkflow/output_workflow_test.go
@@ -3,6 +3,7 @@ package outputworkflow
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -178,6 +179,7 @@ func TestUnifiedFindingsHandling_renderFilesAndUI(t *testing.T) {
 	invocationContextMock.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
 	invocationContextMock.EXPECT().GetRuntimeInfo().Return(
 		runtimeinfo.New(runtimeinfo.WithName("snyk-cli"), runtimeinfo.WithVersion("1.2.3"))).AnyTimes()
+	invocationContextMock.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 	byteBuffer := &bytes.Buffer{}
 	outputDestination.EXPECT().GetWriter().Return(byteBuffer).AnyTimes()


### PR DESCRIPTION
This PR replaces the usage of Background Contexts by using the context given in the InvocationContext.