### PR TITLE
refactor: order uv handling before unified-test-api orchestrator in G…

### DIFF
--- a/internal/common/depgraph.go
+++ b/internal/common/depgraph.go
@@ -40,38 +40,58 @@ type RawDepGraphWithMeta struct {
 }
 
 // GetDepGraph retrieves the dependency graph for the given invocation context.
+//
+// Priority: uv handling (uv.lock + FeatureFlagUvCLI) takes precedence over the unified-test-api
+// orchestrator path so that uv repos keep their SBOM-resolution behavior as the unified FF rolls out.
 func GetDepGraph(ictx workflow.InvocationContext, inputDir string) ([]RawDepGraphWithMeta, error) {
-	engine := ictx.GetEngine()
 	config := ictx.GetConfiguration()
 	logger := ictx.GetEnhancedLogger()
 	errFactory := errors.NewErrorFactory(logger)
 
-	// Branch off to get dep-graphs plus project identities from the orchestrator.
-	// TODO: move this FF check and branching logic into the dep-graph extension. The main workflow should be the canonical entrypoint for all OS flows.
-	if config.GetBool(constants.FeatureFlagUseUnifiedTestAPIForOSCliTest) {
-		opts, err := ecosystems.NewPluginOptionsFromRawFlags(config.GetStringSlice(configuration.RAW_CMD_ARGS))
-		if err != nil {
-			return nil, errFactory.NewDepGraphWorkflowError(err)
-		}
-		return getDepgraphsFromOrchestrator(ictx, inputDir, opts)
-	}
-
-	depGraphConfig := config.Clone()
 	allProjects := config.GetBool(flags.FlagAllProjects)
 	fileFlag := config.GetString(flags.FlagFile)
 
-	// Check if uv support should trigger, first check if uv.lock exists and then check if the FF is enabled.
-	// TODO: move this FF check and branching logic into the dep-graph extension.
+	// FeatureFlagUvCLI is only looked up when uv.lock is present, matching the prior cascading check.
 	uvLockExists := util.HasUvLockFile(inputDir, fileFlag, allProjects, logger)
-	if uvLockExists {
-		ffUvCLI := config.GetBool(constants.FeatureFlagUvCLI)
-		if ffUvCLI {
-			logger.Info().Msg("uv support enabled and uv.lock found, using SBOM resolution in depgraph workflow")
-			depGraphConfig.Set("use-sbom-resolution", true)
-		} else {
-			logger.Info().Msg("uv.lock found but uv feature flag disabled, using standard depgraph workflow")
-		}
-	} else {
+	useUv := uvLockExists && config.GetBool(constants.FeatureFlagUvCLI)
+
+	if !useUv && config.GetBool(constants.FeatureFlagUseUnifiedTestAPIForOSCliTest) {
+		return resolveViaOrchestrator(ictx, inputDir, errFactory)
+	}
+	return resolveViaWorkflow(ictx, inputDir, useUv, uvLockExists, errFactory)
+}
+
+func resolveViaOrchestrator(
+	ictx workflow.InvocationContext,
+	inputDir string,
+	errFactory *errors.ErrorFactory,
+) ([]RawDepGraphWithMeta, error) {
+	config := ictx.GetConfiguration()
+	opts, err := ecosystems.NewPluginOptionsFromRawFlags(config.GetStringSlice(configuration.RAW_CMD_ARGS))
+	if err != nil {
+		return nil, errFactory.NewDepGraphWorkflowError(err)
+	}
+	return getDepgraphsFromOrchestrator(ictx, inputDir, opts)
+}
+
+func resolveViaWorkflow(
+	ictx workflow.InvocationContext,
+	inputDir string,
+	useUv, uvLockExists bool,
+	errFactory *errors.ErrorFactory,
+) ([]RawDepGraphWithMeta, error) {
+	engine := ictx.GetEngine()
+	config := ictx.GetConfiguration()
+	logger := ictx.GetEnhancedLogger()
+
+	depGraphConfig := config.Clone()
+	switch {
+	case useUv:
+		logger.Info().Msg("uv support enabled and uv.lock found, using SBOM resolution in depgraph workflow")
+		depGraphConfig.Set("use-sbom-resolution", true)
+	case uvLockExists:
+		logger.Info().Msg("uv.lock found but uv feature flag disabled, using standard depgraph workflow")
+	default:
 		logger.Info().Msg("Invoking depgraph workflow")
 	}
 


### PR DESCRIPTION
## Summary
Reorder the FF checks in `GetDepGraph` so uv handling (uv.lock + `enableUvCLI`) takes priority over the `unified-test-api-os-cli` orchestrator path. No behavior change today (`unified-test-api-os-cli` is at 0%) — this is a prep change so the orchestrator can roll out without regressing uv repos, which currently lose SBOM resolution because the unified FF short-circuits at the top of `GetDepGraph` before uv detection runs.

FF lookups stay cascaded: `enableUvCLI` only reads when uv.lock exists, unified FF only reads when uv doesn't apply.

## Behavior matrix

| `uv.lock` present | `enableUvCLI` | `unified-test-api-os-cli` | Path                                                  | Changed? |
|---|---|---|---|---|
| yes | on  | on  | depgraph workflow + `use-sbom-resolution=true`         | **yes** — was orchestrator, now correctly uv |
| yes | on  | off | depgraph workflow + `use-sbom-resolution=true`         | no       |
| yes | off | on  | ecosystems orchestrator                                | **yes** — was orchestrator (same), but reachable now |
| yes | off | off | depgraph workflow (no SBOM flag)                       | no (one log line dropped) |
| no  | n/a | on  | ecosystems orchestrator                                | no       |
| no  | n/a | off | depgraph workflow                                      | no       |

Only the first row is a meaningful behavior change, and it only fires once `unified-test-api-os-cli` is rolled out — which is the regression this PR exists to prevent.