### PR TITLE
fix: increase reachability poll timeout from 2min to 20min

### DIFF
--- a/internal/reachability/client.go
+++ b/internal/reachability/client.go
@@ -33,7 +33,7 @@ const (
 
 	minPollInteval      = 1 * time.Second
 	defaultPollInterval = 2 * time.Second
-	defaultPollTimeout  = 2 * time.Minute
+	defaultPollTimeout  = 20 * time.Minute // was 2 min; backend job timeout is 1h, large bundles can take 15+ min
 )
 
 // Client defines the interface for reachability analysis operations.


### PR DESCRIPTION
## Summary

- Bumps `defaultPollTimeout` in `internal/reachability/client.go` from `2 * time.Minute` to `20 * time.Minute`
- The backend (`sast-analysis-api`) has a job timeout of 1h — the 2-minute CLI default was never aligned with this
- Confirmed via Datadog: a successful reachability job on a large Gradle monorepo (~300MB bundle, 200+ subprojects) took 17 minutes. The CLI abandoned the poll 15 minutes earlier, producing `timed out waiting for reachability results` and falling back to a non-reachability scan
- No tests need updating — existing tests pass explicit `PollTimeout` values and are unaffected by the default

Fixes [FAN-148](https://snyksec.atlassian.net/browse/FAN-148)


[FAN-148]: https://snyksec.atlassian.net/browse/FAN-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ