### PR TITLE
fix: set NormalisedTargetFile from resolver metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/muesli/termenv v0.16.0
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/rs/zerolog v1.34.0
-	github.com/snyk/cli-extension-dep-graph v1.18.1
+	github.com/snyk/cli-extension-dep-graph v1.20.0
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90
 	github.com/snyk/go-application-framework v0.0.0-20260511100036-100e7116aec5
@@ -29,6 +29,7 @@ require (
 require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/BurntSushi/toml v1.6.0 // indirect
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/alexbrainman/sspi v0.0.0-20210105120005-909beea2cc74 // indirect

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
-github.com/snyk/cli-extension-dep-graph v1.18.1 h1:SLCYlWkhxrOBy9aC2O6lhN2bCbbPzNGxSxemhGnEhSE=
-github.com/snyk/cli-extension-dep-graph v1.18.1/go.mod h1:+dNp/k/G/RXr67AsUMAcr0KRmSYC1HtEgffHF7ifjrg=
+github.com/snyk/cli-extension-dep-graph v1.20.0 h1:wFZHfVV0UJwjdOty7DIRkdOhev0QkXKwP4NXrWQETxY=
+github.com/snyk/cli-extension-dep-graph v1.20.0/go.mod h1:+dNp/k/G/RXr67AsUMAcr0KRmSYC1HtEgffHF7ifjrg=
 github.com/snyk/code-client-go v1.24.5 h1:ySsfTeaNmi3nWSuM3YaVIiSAG+H/ikD2hACxqneIZJw=
 github.com/snyk/code-client-go v1.24.5/go.mod h1:YYggK3UbOHl5rg7uBhLzsKZBFNavcwFUse/EWCKWdzw=
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3YKLR5LJbqL8WJmUYgDSbFKREIY79g0=

--- a/internal/common/depgraph.go
+++ b/internal/common/depgraph.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 
 	"github.com/rs/zerolog"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/orchestrator"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
+
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/orchestrator"
 
 	"github.com/snyk/cli-extension-os-flows/internal/constants"
 	"github.com/snyk/cli-extension-os-flows/internal/errors"
@@ -56,6 +57,7 @@ func GetDepGraph(ictx workflow.InvocationContext, inputDir string) ([]RawDepGrap
 	useUv := uvLockExists && config.GetBool(constants.FeatureFlagUvCLI)
 
 	if !useUv && config.GetBool(orchestrator.FlagUnifiedTestAPIOsCLI.Key) {
+		logger.Info().Msgf("Using unifed scanners")
 		return resolveViaOrchestrator(ictx, inputDir, errFactory)
 	}
 	return resolveViaWorkflow(ictx, inputDir, useUv, uvLockExists, errFactory)
@@ -216,7 +218,7 @@ func mapToRawDepGraphWithMeta(result *ecosystems.SCAResult, target []byte) (*Raw
 
 	return &RawDepGraphWithMeta{
 		Payload:              payload,
-		NormalisedTargetFile: util.DefaultValue(result.ProjectDescriptor.Identity.TargetFile, ""),
+		NormalisedTargetFile: result.ResolverMetadata.NormalisedTargetFile,
 		TargetFileFromPlugin: result.ProjectDescriptor.Identity.TargetFile,
 		Target:               target,
 	}, nil

--- a/internal/common/depgraph_internal_test.go
+++ b/internal/common/depgraph_internal_test.go
@@ -32,6 +32,9 @@ func TestMapToRawDepGraphWithMeta_Success(t *testing.T) {
 				TargetFile: util.Ptr("package.json"),
 			},
 		},
+		ResolverMetadata: &ecosystems.ResolverMetadata{
+			NormalisedTargetFile: "package.json",
+		},
 	}
 
 	raw, err := mapToRawDepGraphWithMeta(result, target)
@@ -61,6 +64,7 @@ func TestMapToRawDepGraphWithMeta_NilTargetFile(t *testing.T) {
 				TargetFile: nil,
 			},
 		},
+		ResolverMetadata: &ecosystems.ResolverMetadata{},
 	}
 
 	raw, err := mapToRawDepGraphWithMeta(result, nil)


### PR DESCRIPTION
Added NormalisedTargetFile to resolver metadata and currently we map the target file from project descriptor (which is nil able) to the display target file what should always be set. This fixes the test issue we have seen when calling the unified test api. 