### PR TITLE
feat(reachability): skip source upload for unsupported codebases [OSF-167]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @snyk/open-source_open-source-leadership @snyk/open-source_unify @snyk/os-flows @snyk/productinfra_devsec-governance-platform @snyk/product-unification_devsec-governance-platform @snyk/developer-experience_cli @cmars
+
+/internal/reachability/sources/ @snyk/open-source_fix-analysis

--- a/internal/commands/ostest/depgraph_flow.go
+++ b/internal/commands/ostest/depgraph_flow.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/rs/zerolog"
 	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
@@ -22,7 +21,6 @@ import (
 	"github.com/snyk/cli-extension-os-flows/internal/legacy/definitions"
 	"github.com/snyk/cli-extension-os-flows/internal/outputworkflow"
 	"github.com/snyk/cli-extension-os-flows/internal/reachability"
-	"github.com/snyk/cli-extension-os-flows/internal/reachability/sources"
 	"github.com/snyk/cli-extension-os-flows/internal/util"
 	"github.com/snyk/cli-extension-os-flows/pkg/flags"
 )
@@ -99,7 +97,7 @@ func RunUnifiedTestFlow(
 		return nil, nil, err
 	}
 
-	if reachabilityOpts != nil && shouldRunReachability(reachabilityOpts.SourceDir, logger) {
+	if reachabilityOpts != nil && common.ShouldRunReachability(reachabilityOpts.SourceDir, logger) {
 		progressBar.SetTitle(constants.UploadingSourceCodeMessage)
 
 		scanID, scanErr := reachability.GetReachabilityID(
@@ -390,20 +388,4 @@ type DepGraphWithMeta struct {
 	Payload              *testapi.IoSnykApiV1testdepgraphRequestDepGraph
 	DisplayTargetFile    string
 	TargetFileFromPlugin string
-}
-
-// shouldRunReachability checks whether the source directory contains any files
-// in a reachability-supported language. On error inspecting the directory we
-// fall through (return true) so a transient IO issue never costs the user a
-// scan they asked for; the existing upload path will surface the real error.
-func shouldRunReachability(sourceDir string, logger *zerolog.Logger) bool {
-	hasSources, err := sources.HasSupportedSources(sourceDir, logger)
-	if err != nil {
-		logger.Warn().Err(err).Str("sourceDir", sourceDir).Msg("Failed to inspect source directory for reachability; proceeding with upload")
-		return true
-	}
-	if !hasSources {
-		logger.Info().Str("sourceDir", sourceDir).Msg("No reachability-supported source files found; skipping upload")
-	}
-	return hasSources
 }

--- a/internal/commands/ostest/depgraph_flow.go
+++ b/internal/commands/ostest/depgraph_flow.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
@@ -21,6 +22,7 @@ import (
 	"github.com/snyk/cli-extension-os-flows/internal/legacy/definitions"
 	"github.com/snyk/cli-extension-os-flows/internal/outputworkflow"
 	"github.com/snyk/cli-extension-os-flows/internal/reachability"
+	"github.com/snyk/cli-extension-os-flows/internal/reachability/sources"
 	"github.com/snyk/cli-extension-os-flows/internal/util"
 	"github.com/snyk/cli-extension-os-flows/pkg/flags"
 )
@@ -97,7 +99,7 @@ func RunUnifiedTestFlow(
 		return nil, nil, err
 	}
 
-	if reachabilityOpts != nil {
+	if reachabilityOpts != nil && shouldRunReachability(reachabilityOpts.SourceDir, logger) {
 		progressBar.SetTitle(constants.UploadingSourceCodeMessage)
 
 		scanID, scanErr := reachability.GetReachabilityID(
@@ -388,4 +390,20 @@ type DepGraphWithMeta struct {
 	Payload              *testapi.IoSnykApiV1testdepgraphRequestDepGraph
 	DisplayTargetFile    string
 	TargetFileFromPlugin string
+}
+
+// shouldRunReachability checks whether the source directory contains any files
+// in a reachability-supported language. On error inspecting the directory we
+// fall through (return true) so a transient IO issue never costs the user a
+// scan they asked for; the existing upload path will surface the real error.
+func shouldRunReachability(sourceDir string, logger *zerolog.Logger) bool {
+	hasSources, err := sources.HasSupportedSources(sourceDir, logger)
+	if err != nil {
+		logger.Warn().Err(err).Str("sourceDir", sourceDir).Msg("Failed to inspect source directory for reachability; proceeding with upload")
+		return true
+	}
+	if !hasSources {
+		logger.Info().Str("sourceDir", sourceDir).Msg("No reachability-supported source files found; skipping upload")
+	}
+	return hasSources
 }

--- a/internal/commands/ostest/depgraph_flow_test.go
+++ b/internal/commands/ostest/depgraph_flow_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -380,6 +382,8 @@ func Test_RunUnifiedTestFlow_ReachabilityFailureFallback(t *testing.T) {
 	t.Parallel()
 	h := newFlowTestHarness(t)
 
+	sourceDir := tempDirWithJSFile(t)
+
 	h.instr.EXPECT().RecordCodeUploadTime(gomock.Any()).Times(1)
 	h.instr.EXPECT().RecordOSAnalysisTime(gomock.Any()).Times(1)
 	h.registerDepGraphs(1)
@@ -411,11 +415,55 @@ func Test_RunUnifiedTestFlow_ReachabilityFailureFallback(t *testing.T) {
 		FileUploadClient:   fileupload.NewFakeClient(),
 		ReachabilityClient: fakeReachabilityClient,
 		DeeproxyClient:     deeproxy.NewFakeClient(deeproxy.AllowList{Extensions: []string{".js"}}, nil),
-	}, orgUUID, nil, &common.ReachabilityOpts{SourceDir: "."})
+	}, orgUUID, nil, &common.ReachabilityOpts{SourceDir: sourceDir})
 
 	require.NoError(t, err, "scan should succeed even when reachability fails")
 	require.NotNil(t, capturedErr, "OutputError should have been called with a warning")
 	assert.Contains(t, capturedErr.Error(), "Reachability analysis failed")
+}
+
+func Test_RunUnifiedTestFlow_SkipsReachabilityWhenNoSupportedSources(t *testing.T) {
+	t.Parallel()
+	h := newFlowTestHarness(t)
+
+	// Source dir with only unsupported files — reachability must be skipped.
+	sourceDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "main.go"), []byte("package main"), 0o600))
+
+	// RecordCodeUploadTime is NOT expected — its absence asserts that the
+	// reachability upload path was skipped.
+	h.instr.EXPECT().RecordOSAnalysisTime(gomock.Any()).Times(1)
+	h.registerDepGraphs(1)
+
+	mockTestClient := newAssertingTestClient(t, h.ctrl, func(t *testing.T, params testapi.StartTestParams) {
+		t.Helper()
+		depGraphSubject, err := params.Subject().AsDepGraphSubjectCreate()
+		require.NoError(t, err)
+
+		_, hasScanID := depGraphSubject.DepGraph.Get("reachabilityScanId")
+		assert.False(t, hasScanID, "depgraph must not be enriched when reachability is skipped")
+	})
+
+	// Reachability client that would panic if called — proves it isn't.
+	fakeReachabilityClient := reachability.NewFakeClient(uuid.New())
+
+	ctx := h.buildContext()
+
+	_, _, err := ostest.RunUnifiedTestFlow(ctx, ".", common.FlowClients{
+		TestClient:         mockTestClient,
+		FileUploadClient:   fileupload.NewFakeClient(),
+		ReachabilityClient: fakeReachabilityClient,
+		DeeproxyClient:     deeproxy.NewFakeClient(deeproxy.AllowList{}, nil),
+	}, orgUUID, nil, &common.ReachabilityOpts{SourceDir: sourceDir})
+
+	require.NoError(t, err)
+}
+
+func tempDirWithJSFile(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.js"), []byte("console.log('hi')"), 0o600))
+	return dir
 }
 
 func TestMappingTargetParamsToDepGraph(t *testing.T) {

--- a/internal/commands/ostest/sbom_flow_test.go
+++ b/internal/commands/ostest/sbom_flow_test.go
@@ -3,6 +3,8 @@ package ostest_test
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"regexp"
 	"testing"
 	"time"
@@ -230,6 +232,37 @@ func Test_RunSbomFlow_NoReachability_HumanReadable(t *testing.T) {
 
 	// Verify file upload client was called only for SBOM
 	require.Equal(t, 1, ffc.GetUploadCount(), "Expected 1 upload (SBOM only)")
+}
+
+func Test_RunSbomFlow_SkipsSourceUploadWhenNoSupportedSources(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ef := errors.NewErrorFactory(&nopLogger)
+	mockIctx, mockTestClient, ffc, fdc, orgID, sbomPath, _ := setupTest(t, ctrl, true)
+	ctx := t.Context()
+	ctx = cmdctx.WithIctx(ctx, mockIctx)
+	ctx = cmdctx.WithConfig(ctx, mockIctx.GetConfiguration())
+	ctx = cmdctx.WithLogger(ctx, &nopLogger)
+	ctx = cmdctx.WithErrorFactory(ctx, ef)
+	ctx = cmdctx.WithProgressBar(ctx, &nopProgressBar)
+
+	// Source dir with only unsupported files — upload must be skipped.
+	sourceDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "main.go"), []byte("package main"), 0o600))
+
+	_, _, err := common.RunSbomFlow(
+		ctx,
+		sbomPath,
+		common.FlowClients{TestClient: mockTestClient, FileUploadClient: ffc, DeeproxyClient: fdc},
+		orgID,
+		nil,
+		&common.ReachabilityOpts{SourceDir: sourceDir},
+		nil, ostest.RunTestWithResources,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, ffc.GetUploadCount(), "Expected only the SBOM upload; source code upload must be skipped")
 }
 
 //nolint:gocritic // Not important for tests.

--- a/internal/commands/ostest/testdata/test_dir/app.js
+++ b/internal/commands/ostest/testdata/test_dir/app.js
@@ -1,0 +1,1 @@
+console.log("hello");

--- a/internal/common/dfly_depgraph_flow.go
+++ b/internal/common/dfly_depgraph_flow.go
@@ -121,7 +121,7 @@ func RunDflyDepgraphFlow(
 
 	resources := []testapi.TestResourceCreateItem{uploadResource}
 
-	if reachabilityOpts != nil {
+	if reachabilityOpts != nil && ShouldRunReachability(reachabilityOpts.SourceDir, logger) {
 		progressBar.SetTitle(constants.UploadingSourceCodeMessage)
 
 		var sourceResource testapi.TestResourceCreateItem

--- a/internal/common/dfly_depgraph_flow_test.go
+++ b/internal/common/dfly_depgraph_flow_test.go
@@ -3,6 +3,8 @@ package common_test
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"regexp"
 	"testing"
 	"time"
@@ -240,6 +242,50 @@ func Test_RunDflyDepgraphFlow_DepgraphResolverFails(t *testing.T) {
 		orgID, nil, nil, nil, ostest.RunTestWithResources,
 	)
 	assert.ErrorContains(t, err, "failed to extract dependency graphs")
+}
+
+func Test_RunDflyDepgraphFlow_SkipsSourceUploadWhenNoSupportedSources(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Source dir with only unsupported files — reachability upload must be skipped.
+	sourceDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "main.go"), []byte("package main"), 0o600))
+
+	orgID := uuid.New()
+	mockIctx := setupDflyInvocationContext(t, ctrl, true)
+	mockTestClient := setupDflyTestClient(t, ctrl)
+	ffc := fileupload.NewFakeClient()
+	fdr := common.NewFakeDepgraphResolver([]common.DepgraphWithIdentity{
+		{
+			Identity: common.Identity{TargetFile: "proj/package.json"},
+			DepGraph: &depgraph.DepGraph{
+				SchemaVersion: "1.2.0",
+				PkgManager:    depgraph.PkgManager{Name: "npm"},
+				Pkgs: []depgraph.Pkg{
+					{ID: "proj@1.0.0", Info: depgraph.PkgInfo{Name: "proj", Version: "1.0.0"}},
+				},
+				Graph: depgraph.Graph{RootNodeID: "root"},
+			},
+		},
+	}, nil)
+
+	ctx := t.Context()
+	ctx = cmdctx.WithIctx(ctx, mockIctx)
+	ctx = cmdctx.WithLogger(ctx, &dflyNopLogger)
+	ctx = cmdctx.WithProgressBar(ctx, &dflyNopProgressBar)
+	ctx = cmdctx.WithConfig(ctx, mockIctx.GetConfiguration())
+
+	_, _, err := common.RunDflyDepgraphFlow(
+		ctx, ".", fdr,
+		common.FlowClients{FileUploadClient: ffc, TestClient: mockTestClient},
+		orgID, nil, &common.ReachabilityOpts{SourceDir: sourceDir}, nil,
+		ostest.RunTestWithResources,
+	)
+	require.NoError(t, err)
+
+	// Only the depgraph upload; the source code upload must be skipped.
+	assert.Equal(t, 1, ffc.GetUploadCount())
 }
 
 func Test_RunDflyDepgraphFlow_ConfigMetadataForwarded(t *testing.T) {

--- a/internal/common/reachability.go
+++ b/internal/common/reachability.go
@@ -26,7 +26,10 @@ func ShouldRunReachability(sourceDir string, logger *zerolog.Logger) bool {
 		return true
 	}
 	if !hasSources {
-		logger.Info().Str("sourceDir", sourceDir).Msg("No reachability-supported source files found; skipping upload")
+		logger.Info().
+			Str("sourceDir", sourceDir).
+			Interface("supportedLanguages", sources.SupportedExtensionsByLanguage).
+			Msg("No reachability-supported source files found; skipping upload")
 	}
 	return hasSources
 }

--- a/internal/common/reachability.go
+++ b/internal/common/reachability.go
@@ -5,13 +5,31 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 
 	"github.com/snyk/cli-extension-os-flows/internal/commands/clientsetup"
 	"github.com/snyk/cli-extension-os-flows/internal/commands/cmdctx"
 	"github.com/snyk/cli-extension-os-flows/internal/constants"
+	"github.com/snyk/cli-extension-os-flows/internal/reachability/sources"
 	"github.com/snyk/cli-extension-os-flows/pkg/flags"
 )
+
+// ShouldRunReachability reports whether the source directory contains any files
+// in a reachability-supported language. On error inspecting the directory we
+// fall through (return true) so a transient IO issue never costs the user a
+// scan they asked for — the existing upload path will surface the real error.
+func ShouldRunReachability(sourceDir string, logger *zerolog.Logger) bool {
+	hasSources, err := sources.HasSupportedSources(sourceDir, logger)
+	if err != nil {
+		logger.Warn().Err(err).Str("sourceDir", sourceDir).Msg("Failed to inspect source directory for reachability; proceeding with upload")
+		return true
+	}
+	if !hasSources {
+		logger.Info().Str("sourceDir", sourceDir).Msg("No reachability-supported source files found; skipping upload")
+	}
+	return hasSources
+}
 
 // ResolveMonitorReachabilityOpts determines the reachability options for the monitor flow.
 // It checks feature flags and org settings, returning an error when reachability is requested but unavailable.

--- a/internal/common/sbom_flow.go
+++ b/internal/common/sbom_flow.go
@@ -68,7 +68,7 @@ func RunSbomFlow(
 
 	resources := []testapi.TestResourceCreateItem{sbomResource}
 
-	if reachabilityOpts != nil {
+	if reachabilityOpts != nil && ShouldRunReachability(reachabilityOpts.SourceDir, logger) {
 		progressBar.SetTitle(constants.UploadingSourceCodeMessage)
 
 		var sourceResource testapi.TestResourceCreateItem

--- a/internal/reachability/sources/sources.go
+++ b/internal/reachability/sources/sources.go
@@ -4,6 +4,7 @@ package sources
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 
@@ -35,6 +36,10 @@ var supportedExtensions = map[string]struct{}{
 // the org / feature flags before invoking this function — it only inspects
 // the file tree.
 func HasSupportedSources(path string, logger *zerolog.Logger) (bool, error) {
+	if _, err := os.Stat(path); err != nil {
+		return false, fmt.Errorf("failed to stat %s: %w", path, err)
+	}
+
 	files, err := listsources.ForPath(path, logger, runtime.NumCPU())
 	if err != nil {
 		return false, fmt.Errorf("failed to list files in %s: %w", path, err)

--- a/internal/reachability/sources/sources.go
+++ b/internal/reachability/sources/sources.go
@@ -14,7 +14,7 @@ import (
 )
 
 // SupportedExtensionsByLanguage maps each reachability-supported language to
-// the file extensions Code recognises for it. Mirrors the corresponding subset
+// the file extensions Code recognizes for it. Mirrors the corresponding subset
 // of snyk/deepcode analysis/analysis_settings/analysis_settings.json (the
 // authoritative source) and must be re-synced when Code adds extensions for
 // Java/JS/TS/Python/C#. The public docs at

--- a/internal/reachability/sources/sources.go
+++ b/internal/reachability/sources/sources.go
@@ -2,7 +2,32 @@
 // reachability analysis based purely on its contents.
 package sources
 
-import "github.com/rs/zerolog"
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+
+	"github.com/rs/zerolog"
+
+	listsources "github.com/snyk/cli-extension-os-flows/internal/files"
+)
+
+// supportedExtensions is the curated set of file extensions that belong to a
+// reachability-supported language. Mirrors
+// https://docs.snyk.io/manage-risk/prioritize-issues-for-fixing/reachability-analysis
+// and must be kept in sync manually when reachability adds a language.
+// Verify against the registry and sast-analysis-api definitions before extending.
+var supportedExtensions = map[string]struct{}{
+	".java": {},
+	".js":   {},
+	".jsx":  {},
+	".mjs":  {},
+	".cjs":  {},
+	".ts":   {},
+	".tsx":  {},
+	".py":   {},
+	".cs":   {},
+}
 
 // HasSupportedSources reports whether the given directory contains at least
 // one file whose extension belongs to a language supported by reachability
@@ -10,7 +35,27 @@ import "github.com/rs/zerolog"
 // the org / feature flags before invoking this function — it only inspects
 // the file tree.
 func HasSupportedSources(path string, logger *zerolog.Logger) (bool, error) {
-	_ = path
-	_ = logger
+	files, err := listsources.ForPath(path, logger, runtime.NumCPU())
+	if err != nil {
+		return false, fmt.Errorf("failed to list files in %s: %w", path, err)
+	}
+
+	for f := range files {
+		if _, ok := supportedExtensions[filepath.Ext(f)]; ok {
+			unblockFileWalker(files)
+			return true, nil
+		}
+	}
 	return false, nil
+}
+
+// unblockFileWalker drains the remaining file paths in the background so the
+// producer goroutines inside utils.FileFilter — which accept no context and
+// cannot be cancelled — can finish sending and exit cleanly after we've
+// already found what we were looking for.
+func unblockFileWalker(files <-chan string) {
+	go func() {
+		for range files {
+		}
+	}()
 }

--- a/internal/reachability/sources/sources.go
+++ b/internal/reachability/sources/sources.go
@@ -47,6 +47,7 @@ func HasSupportedSources(path string, logger *zerolog.Logger) (bool, error) {
 
 	for f := range files {
 		if _, ok := supportedExtensions[filepath.Ext(f)]; ok {
+			logger.Info().Str("extension", filepath.Ext(f)).Msg("supported extension found")
 			unblockFileWalker(files)
 			return true, nil
 		}

--- a/internal/reachability/sources/sources.go
+++ b/internal/reachability/sources/sources.go
@@ -1,0 +1,16 @@
+// Package sources decides whether a directory is worth uploading for
+// reachability analysis based purely on its contents.
+package sources
+
+import "github.com/rs/zerolog"
+
+// HasSupportedSources reports whether the given directory contains at least
+// one file whose extension belongs to a language supported by reachability
+// analysis. Callers must independently verify reachability is enabled for
+// the org / feature flags before invoking this function — it only inspects
+// the file tree.
+func HasSupportedSources(path string, logger *zerolog.Logger) (bool, error) {
+	_ = path
+	_ = logger
+	return false, nil
+}

--- a/internal/reachability/sources/sources.go
+++ b/internal/reachability/sources/sources.go
@@ -56,11 +56,11 @@ func HasSupportedSources(path string, logger *zerolog.Logger) (bool, error) {
 
 // unblockFileWalker drains the remaining file paths in the background so the
 // producer goroutines inside utils.FileFilter — which accept no context and
-// cannot be cancelled — can finish sending and exit cleanly after we've
+// cannot be canceled — can finish sending and exit cleanly after we've
 // already found what we were looking for.
 func unblockFileWalker(files <-chan string) {
 	go func() {
-		for range files {
+		for range files { //nolint:revive // intentional drain to unblock producer
 		}
 	}()
 }

--- a/internal/reachability/sources/sources.go
+++ b/internal/reachability/sources/sources.go
@@ -13,22 +13,29 @@ import (
 	listsources "github.com/snyk/cli-extension-os-flows/internal/files"
 )
 
-// supportedExtensions is the curated set of file extensions that belong to a
-// reachability-supported language. Mirrors
+// SupportedExtensionsByLanguage maps each reachability-supported language to
+// the file extensions Code recognises for it. Mirrors the corresponding subset
+// of snyk/deepcode analysis/analysis_settings/analysis_settings.json (the
+// authoritative source) and must be re-synced when Code adds extensions for
+// Java/JS/TS/Python/C#. The public docs at
 // https://docs.snyk.io/manage-risk/prioritize-issues-for-fixing/reachability-analysis
-// and must be kept in sync manually when reachability adds a language.
-// Verify against the registry and sast-analysis-api definitions before extending.
-var supportedExtensions = map[string]struct{}{
-	".java": {},
-	".js":   {},
-	".jsx":  {},
-	".mjs":  {},
-	".cjs":  {},
-	".ts":   {},
-	".tsx":  {},
-	".py":   {},
-	".cs":   {},
+// list the supported languages but not the full extension set.
+var SupportedExtensionsByLanguage = map[string][]string{
+	"Java":                  {".java", ".jsp", ".jspx"},
+	"JavaScript/TypeScript": {".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".cts", ".mts", ".vue", ".htm", ".html", ".ejs", ".es", ".es6"},
+	"Python":                {".py"},
+	"C#":                    {".cs", ".aspx"},
 }
+
+var supportedExtensions = func() map[string]struct{} {
+	m := make(map[string]struct{})
+	for _, exts := range SupportedExtensionsByLanguage {
+		for _, ext := range exts {
+			m[ext] = struct{}{}
+		}
+	}
+	return m
+}()
 
 // HasSupportedSources reports whether the given directory contains at least
 // one file whose extension belongs to a language supported by reachability

--- a/internal/reachability/sources/sources_test.go
+++ b/internal/reachability/sources/sources_test.go
@@ -1,0 +1,1 @@
+package sources_test

--- a/internal/reachability/sources/sources_test.go
+++ b/internal/reachability/sources/sources_test.go
@@ -1,1 +1,26 @@
 package sources_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-os-flows/internal/reachability/sources"
+)
+
+func nopLogger() *zerolog.Logger {
+	l := zerolog.New(io.Discard)
+	return &l
+}
+
+func TestHasSupportedSources_EmptyDir_ReturnsFalse(t *testing.T) {
+	dir := t.TempDir()
+
+	got, err := sources.HasSupportedSources(dir, nopLogger())
+
+	require.NoError(t, err)
+	assert.False(t, got)
+}

--- a/internal/reachability/sources/sources_test.go
+++ b/internal/reachability/sources/sources_test.go
@@ -47,7 +47,7 @@ func TestHasSupportedSources_AllSupportedExtensions(t *testing.T) {
 			got, err := sources.HasSupportedSources(dir, nopLogger())
 
 			require.NoError(t, err)
-			assert.True(t, got, "expected %s to be recognised as supported", ext)
+			assert.True(t, got, "expected %s to be recognized as supported", ext)
 		})
 	}
 }

--- a/internal/reachability/sources/sources_test.go
+++ b/internal/reachability/sources/sources_test.go
@@ -37,6 +37,67 @@ func TestHasSupportedSources_SingleJavaFile_ReturnsTrue(t *testing.T) {
 	assert.True(t, got)
 }
 
+func TestHasSupportedSources_AllSupportedExtensions(t *testing.T) {
+	exts := []string{".java", ".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".py", ".cs"}
+	for _, ext := range exts {
+		t.Run(ext, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "file"+ext, "// content")
+
+			got, err := sources.HasSupportedSources(dir, nopLogger())
+
+			require.NoError(t, err)
+			assert.True(t, got, "expected %s to be recognised as supported", ext)
+		})
+	}
+}
+
+func TestHasSupportedSources_OnlyUnsupportedFiles_ReturnsFalse(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.go", "package main")
+	writeFile(t, dir, "README.md", "# hi")
+	writeFile(t, dir, "Gemfile", "source 'https://rubygems.org'")
+	writeFile(t, dir, "script.rb", "puts 'hi'")
+	writeFile(t, dir, "index.php", "<?php ?>")
+
+	got, err := sources.HasSupportedSources(dir, nopLogger())
+
+	require.NoError(t, err)
+	assert.False(t, got)
+}
+
+func TestHasSupportedSources_MixedTree_ReturnsTrue(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.go", "package main")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "frontend", "src"), 0o755))
+	writeFile(t, filepath.Join(dir, "frontend", "src"), "index.ts", "export {}")
+
+	got, err := sources.HasSupportedSources(dir, nopLogger())
+
+	require.NoError(t, err)
+	assert.True(t, got)
+}
+
+func TestHasSupportedSources_RespectsGitignore(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".gitignore", "ignored/\n")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "ignored"), 0o755))
+	writeFile(t, filepath.Join(dir, "ignored"), "App.java", "class App {}")
+	writeFile(t, dir, "main.go", "package main")
+
+	got, err := sources.HasSupportedSources(dir, nopLogger())
+
+	require.NoError(t, err)
+	assert.False(t, got, "supported file under an ignored path must not count")
+}
+
+func TestHasSupportedSources_NonexistentPath_ReturnsError(t *testing.T) {
+	got, err := sources.HasSupportedSources("/this/path/should/not/exist/ever", nopLogger())
+
+	require.Error(t, err)
+	assert.False(t, got)
+}
+
 func writeFile(t *testing.T, dir, name, body string) {
 	t.Helper()
 	p := filepath.Join(dir, name)

--- a/internal/reachability/sources/sources_test.go
+++ b/internal/reachability/sources/sources_test.go
@@ -2,6 +2,8 @@ package sources_test
 
 import (
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -23,4 +25,20 @@ func TestHasSupportedSources_EmptyDir_ReturnsFalse(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.False(t, got)
+}
+
+func TestHasSupportedSources_SingleJavaFile_ReturnsTrue(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "App.java", "class App {}")
+
+	got, err := sources.HasSupportedSources(dir, nopLogger())
+
+	require.NoError(t, err)
+	assert.True(t, got)
+}
+
+func writeFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o600))
 }

--- a/internal/reachability/sources/sources_test.go
+++ b/internal/reachability/sources/sources_test.go
@@ -38,17 +38,18 @@ func TestHasSupportedSources_SingleJavaFile_ReturnsTrue(t *testing.T) {
 }
 
 func TestHasSupportedSources_AllSupportedExtensions(t *testing.T) {
-	exts := []string{".java", ".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".py", ".cs"}
-	for _, ext := range exts {
-		t.Run(ext, func(t *testing.T) {
-			dir := t.TempDir()
-			writeFile(t, dir, "file"+ext, "// content")
+	for lang, exts := range sources.SupportedExtensionsByLanguage {
+		for _, ext := range exts {
+			t.Run(lang+"/"+ext, func(t *testing.T) {
+				dir := t.TempDir()
+				writeFile(t, dir, "file"+ext, "// content")
 
-			got, err := sources.HasSupportedSources(dir, nopLogger())
+				got, err := sources.HasSupportedSources(dir, nopLogger())
 
-			require.NoError(t, err)
-			assert.True(t, got, "expected %s to be recognized as supported", ext)
-		})
+				require.NoError(t, err)
+				assert.True(t, got, "expected %s (%s) to be recognized as supported", ext, lang)
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Skip the reachability source-code upload step when the target directory contains no files in a reachability-supported language (Java, JS/TS, Python, C#). Saves a network round-trip and the cost of streaming bytes the backend would ignore for Go/Ruby/PHP/etc codebases.
- New package `internal/reachability/sources` exposing `HasSupportedSources(path, logger)` — walks the tree via the existing `listsources.ForPath` (so `.gitignore`/`.dcignore` are honoured) and returns `true` on first matching extension.
- New `common.ShouldRunReachability` helper gates all three call sites: `ostest/depgraph_flow.go`, `common/sbom_flow.go`, `common/dfly_depgraph_flow.go`. On stat errors the helper falls through to upload (errs on the side of running the scan the user asked for).


🤖 Generated with [Claude Code](https://claude.com/claude-code)