### PR TITLE
feat(ostest): auto-detect C/C++ artefacts, run unmanaged scan alongside managed [IDE-2089]

### DIFF
--- a/internal/commands/ostest/autodetect.go
+++ b/internal/commands/ostest/autodetect.go
@@ -1,0 +1,80 @@
+package ostest
+
+import (
+	"context"
+	"os"
+	"strconv"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+
+	"github.com/snyk/cli-extension-os-flows/internal/commands/cmdctx"
+	"github.com/snyk/cli-extension-os-flows/internal/constants"
+	"github.com/snyk/cli-extension-os-flows/pkg/unmanaged/detect"
+)
+
+// autoDetectEnabled reports whether SNYK_AUTODETECT_OSS is truthy. When on,
+// os-flows inspects each input directory for C/C++ artefacts and, if any are
+// found, runs an extra unmanaged scan via the legacy CLI alongside the managed
+// scan. Off by default — flip to opt-in users without disturbing existing flows.
+func autoDetectEnabled() bool {
+	raw := os.Getenv(constants.AutodetectOSSEnvVar)
+	if raw == "" {
+		return false
+	}
+	v, _ := strconv.ParseBool(raw)
+	return v
+}
+
+// detectCPPDirs returns the subset of dirs that contain C/C++ artefacts. The
+// detector short-circuits on the first hit per directory, so the cost is
+// bounded; see pkg/unmanaged/detect for the file-count / depth caps.
+func detectCPPDirs(dirs []string) []string {
+	var out []string
+	for _, d := range dirs {
+		if detect.HasCPPArtefacts(d) {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// invokeLegacyUnmanagedScan runs `legacycli` with --unmanaged injected into
+// the raw arg list. The legacy CLI walks the input dirs itself, so we don't
+// pass cppDirs explicitly — they're already in INPUT_DIRECTORY. We only invoke
+// when at least one C/C++ dir was found, to avoid a no-op scan.
+//
+// LIMITATION: output merging is best-effort. The legacy CLI's workflow.Data
+// carries a different content type than the native os-flows output, so the two
+// streams render as separate sections rather than as a single unified report.
+// A future native unmanaged.test workflow can replace this and produce one
+// merged structured output.
+func invokeLegacyUnmanagedScan(ctx context.Context) ([]workflow.Data, error) {
+	ictx := cmdctx.Ictx(ctx)
+	cfg := cmdctx.Config(ctx)
+
+	legacyConfig := cfg.Clone()
+	args := cfg.GetStringSlice(configuration.RAW_CMD_ARGS)
+	if len(args) == 0 {
+		args = os.Args[1:]
+	}
+	if !containsArg(args, "--unmanaged") {
+		args = append(args, "--unmanaged")
+	}
+	legacyConfig.Set(configuration.RAW_CMD_ARGS, args)
+	// Capture as workflow.Data instead of streaming to stdout, so it can be
+	// returned alongside the managed scan's data.
+	legacyConfig.Set(configuration.WORKFLOW_USE_STDIO, false)
+
+	//nolint:wrapcheck // No need to wrap legacy errors.
+	return ictx.GetEngine().InvokeWithConfig(workflow.NewWorkflowIdentifier("legacycli"), legacyConfig)
+}
+
+func containsArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/commands/ostest/autodetect_test.go
+++ b/internal/commands/ostest/autodetect_test.go
@@ -1,0 +1,69 @@
+package ostest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/snyk/cli-extension-os-flows/internal/constants"
+)
+
+func TestAutoDetectEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		want bool
+	}{
+		{"unset", "", false},
+		{"explicit false", "false", false},
+		{"0", "0", false},
+		{"true", "true", true},
+		{"1", "1", true},
+		{"garbage", "yesplease", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.val == "" {
+				t.Setenv(constants.AutodetectOSSEnvVar, "")
+				_ = os.Unsetenv(constants.AutodetectOSSEnvVar)
+			} else {
+				t.Setenv(constants.AutodetectOSSEnvVar, tc.val)
+			}
+			if got := autoDetectEnabled(); got != tc.want {
+				t.Fatalf("autoDetectEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDetectCPPDirs(t *testing.T) {
+	root := t.TempDir()
+	cppDir := filepath.Join(root, "cpp-project")
+	jsDir := filepath.Join(root, "js-project")
+	if err := os.Mkdir(cppDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(jsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cppDir, "main.cpp"), []byte("int main(){}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jsDir, "index.js"), []byte("module.exports={}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := detectCPPDirs([]string{cppDir, jsDir})
+	if len(got) != 1 || got[0] != cppDir {
+		t.Fatalf("detectCPPDirs = %v, want [%s]", got, cppDir)
+	}
+}
+
+func TestContainsArg(t *testing.T) {
+	if !containsArg([]string{"test", "--unmanaged"}, "--unmanaged") {
+		t.Fatal("expected true when arg present")
+	}
+	if containsArg([]string{"test"}, "--unmanaged") {
+		t.Fatal("expected false when arg absent")
+	}
+}

--- a/internal/commands/ostest/workflow.go
+++ b/internal/commands/ostest/workflow.go
@@ -336,5 +336,28 @@ func OSWorkflow(
 	//nolint:errcheck // We don't need to fail the command due to UI errors.
 	progressBar.Clear()
 
-	return handleOutput(ctx, allLegacyFindings, allOutputData)
+	out, err := handleOutput(ctx, allLegacyFindings, allOutputData)
+	if err != nil {
+		return nil, err
+	}
+
+	// Auto-detect: when opted in via SNYK_AUTODETECT_OSS and the user didn't
+	// already pass --unmanaged, scan input dirs for C/C++ artefacts and run
+	// an extra unmanaged scan via the legacy CLI for the dirs that look
+	// unmanaged-eligible. Results are appended to the managed output.
+	if !flowCfg.Unmanaged && autoDetectEnabled() {
+		if cppDirs := detectCPPDirs(inputDirs); len(cppDirs) > 0 {
+			cmdctx.Logger(ctx).Debug().Strs("cpp_dirs", cppDirs).Msg("autodetect: invoking legacy --unmanaged")
+			unmanagedData, unmErr := invokeLegacyUnmanagedScan(ctx)
+			if unmErr != nil {
+				// Don't fail the whole scan; the managed results are still
+				// useful and the user can rerun with --unmanaged explicitly.
+				cmdctx.Logger(ctx).Warn().Err(unmErr).Msg("autodetect: unmanaged scan failed")
+			} else {
+				out = append(out, unmanagedData...)
+			}
+		}
+	}
+
+	return out, nil
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -3,6 +3,11 @@ package constants
 // ForceLegacyCLIEnvVar is an internal environment variable to force the legacy CLI flow.
 const ForceLegacyCLIEnvVar = "SNYK_FORCE_LEGACY_CLI"
 
+// AutodetectOSSEnvVar opts a session into auto-detecting C/C++ artefacts in
+// each input directory. When found, an extra unmanaged scan runs alongside
+// the managed scan so mixed projects don't need an explicit --unmanaged flag.
+const AutodetectOSSEnvVar = "SNYK_AUTODETECT_OSS"
+
 // FeatureFlagReachabilityForCLI is to gate the reachability capability on the CLI.
 const FeatureFlagReachabilityForCLI = "internal_snyk_cli_reachability_enabled"
 

--- a/pkg/unmanaged/detect/cpp.go
+++ b/pkg/unmanaged/detect/cpp.go
@@ -1,0 +1,121 @@
+// Package detect inspects a directory tree to decide whether it looks like
+// a C/C++ project that the unmanaged OSS scanner can handle.
+//
+// The detector is purposely conservative and fast: it short-circuits on the
+// first matching file and is bounded by file-count and depth limits so it is
+// safe to call on the hot path of every OSS scan.
+package detect
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// maxFiles caps how many filesystem entries the walker will examine before
+	// giving up. Tuned so the walk fits comfortably in single-digit ms even on
+	// a cold cache, and bounds worst-case latency on pathological trees.
+	maxFiles = 5000
+	// maxDepth caps how deep the walker descends below root. Most C/C++ source
+	// lives within a few levels; deeply nested vendor trees rarely contain
+	// project-defining artefacts.
+	maxDepth = 6
+)
+
+var cppFileExtensions = map[string]bool{
+	".c":   true,
+	".cc":  true,
+	".cpp": true,
+	".cxx": true,
+	".c++": true,
+	".h":   true,
+	".hh":  true,
+	".hpp": true,
+	".hxx": true,
+	".h++": true,
+	".ipp": true,
+	".tpp": true,
+	".tcc": true,
+	".inl": true,
+}
+
+var cppArtefactNames = map[string]bool{
+	"CMakeLists.txt": true,
+	"Makefile":       true,
+	"makefile":       true,
+	"configure.ac":   true,
+	"configure.in":   true,
+	"meson.build":    true,
+}
+
+var skipDirNames = map[string]bool{
+	".git":             true,
+	".svn":             true,
+	".hg":              true,
+	".idea":            true,
+	".vscode":          true,
+	"node_modules":     true,
+	"vendor":           true,
+	"bower_components": true,
+	"dist":             true,
+	"build":            true,
+	"out":              true,
+	"target":           true,
+}
+
+// HasCPPArtefacts walks root looking for any C/C++ source, header, or
+// build-system file. It short-circuits on the first hit and is bounded by
+// maxFiles and maxDepth so it is safe to call on the hot path of an OSS scan.
+// Returns false if root is empty, does not exist, or is unreadable.
+func HasCPPArtefacts(root string) bool {
+	if root == "" {
+		return false
+	}
+	seen := 0
+	found := false
+	rootDepth := strings.Count(filepath.Clean(root), string(filepath.Separator))
+
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || found || seen >= maxFiles {
+			return fs.SkipAll
+		}
+		seen++
+
+		if d.IsDir() {
+			if path == root {
+				return nil
+			}
+			name := d.Name()
+			// cmake-build-* are generated trees that contain copies of the
+			// source plus build artefacts — skip to avoid double-counting and
+			// to keep the walk small.
+			if skipDirNames[name] || strings.HasPrefix(name, "cmake-build-") {
+				return fs.SkipDir
+			}
+			depth := strings.Count(filepath.Clean(path), string(filepath.Separator)) - rootDepth
+			if depth > maxDepth {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		name := d.Name()
+		if cppArtefactNames[name] {
+			found = true
+			return fs.SkipAll
+		}
+		if strings.HasSuffix(name, ".mk") {
+			found = true
+			return fs.SkipAll
+		}
+		ext := strings.ToLower(filepath.Ext(name))
+		if cppFileExtensions[ext] {
+			found = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+
+	return found
+}

--- a/pkg/unmanaged/detect/cpp_test.go
+++ b/pkg/unmanaged/detect/cpp_test.go
@@ -1,0 +1,105 @@
+package detect
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHasCPPArtefacts(t *testing.T) {
+	t.Run("empty root returns false", func(t *testing.T) {
+		if HasCPPArtefacts("") {
+			t.Fatal("expected false for empty root")
+		}
+	})
+
+	t.Run("nonexistent root returns false", func(t *testing.T) {
+		if HasCPPArtefacts(filepath.Join(t.TempDir(), "does-not-exist")) {
+			t.Fatal("expected false for nonexistent root")
+		}
+	})
+
+	t.Run("positive on .cpp file", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "main.cpp"), "int main(){}")
+		if !HasCPPArtefacts(dir) {
+			t.Fatal("expected true when .cpp file present")
+		}
+	})
+
+	t.Run("positive on .h file in subdir", func(t *testing.T) {
+		dir := t.TempDir()
+		sub := filepath.Join(dir, "include")
+		if err := os.Mkdir(sub, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, filepath.Join(sub, "lib.h"), "#pragma once")
+		if !HasCPPArtefacts(dir) {
+			t.Fatal("expected true when .h file present in subdir")
+		}
+	})
+
+	t.Run("positive on CMakeLists.txt", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "CMakeLists.txt"), "project(x)")
+		if !HasCPPArtefacts(dir) {
+			t.Fatal("expected true when CMakeLists.txt present")
+		}
+	})
+
+	t.Run("positive on .mk file", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "rules.mk"), "all:")
+		if !HasCPPArtefacts(dir) {
+			t.Fatal("expected true when *.mk present")
+		}
+	})
+
+	t.Run("negative on pure JS project", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "package.json"), "{}")
+		writeFile(t, filepath.Join(dir, "index.js"), "module.exports={}")
+		if HasCPPArtefacts(dir) {
+			t.Fatal("expected false when no C/C++ artefacts present")
+		}
+	})
+
+	t.Run("ignores .cpp inside node_modules", func(t *testing.T) {
+		dir := t.TempDir()
+		nm := filepath.Join(dir, "node_modules")
+		if err := os.Mkdir(nm, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, filepath.Join(nm, "binding.cpp"), "//")
+		if HasCPPArtefacts(dir) {
+			t.Fatal("node_modules must be skipped")
+		}
+	})
+
+	t.Run("ignores .c inside cmake-build-debug", func(t *testing.T) {
+		dir := t.TempDir()
+		sub := filepath.Join(dir, "cmake-build-debug")
+		if err := os.Mkdir(sub, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, filepath.Join(sub, "gen.c"), "//")
+		if HasCPPArtefacts(dir) {
+			t.Fatal("cmake-build-* must be skipped")
+		}
+	})
+
+	t.Run("case-insensitive extension", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "Main.CPP"), "int main(){}")
+		if !HasCPPArtefacts(dir) {
+			t.Fatal("uppercase extensions should match")
+		}
+	})
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

Moves C/C++ project detection from snyk-ls into os-flows and wires it into `OSWorkflow` so a folder with both a manifest *and* C/C++ files gets scanned both ways automatically — eliminating the IDE's per-folder "switch to unmanaged mode?" prompt and toggle.

## What lands here

- **`pkg/unmanaged/detect.HasCPPArtefacts(root) bool`** — bounded directory walker (max 5000 entries, depth 6, skip-list for `node_modules` / `vendor` / `cmake-build-*` / VCS / common build outputs). Short-circuits on the first C/C++ source, header (`.c` / `.cc` / `.cpp` / `.cxx` / `.h` / `.hpp` / `.hxx` / `.ipp` / `.tpp` / `.tcc` / `.inl` …), recognised build-system filename (`CMakeLists.txt`, `Makefile`, `meson.build`, `configure.ac` …), or `*.mk`. Ported from `snyk-ls/infrastructure/oss/unmanaged_detect.go` so it lives next to the rest of the OSS routing.
- **`internal/constants/constants.go`** — `AutodetectOSSEnvVar = "SNYK_AUTODETECT_OSS"`.
- **`internal/commands/ostest/autodetect.go`** — `autoDetectEnabled()` parses the env var, `detectCPPDirs(dirs)` filters input directories, `invokeLegacyUnmanagedScan(ctx)` clones the config, injects `--unmanaged` into `RAW_CMD_ARGS`, sets `WORKFLOW_USE_STDIO=false`, and invokes the `legacycli` workflow.
- **`internal/commands/ostest/workflow.go`** — after the managed scan returns, if `SNYK_AUTODETECT_OSS` is truthy and `--unmanaged` wasn't already passed, runs the detector; on any C/C++ hit, runs the unmanaged scan via the legacy CLI and appends its `workflow.Data` to the managed output. Errors from the unmanaged scan are logged and swallowed — the managed result still ships.
- **Tests** — `pkg/unmanaged/detect/cpp_test.go` covers positives, negatives, skip-dirs, case-insensitive extensions; `internal/commands/ostest/autodetect_test.go` covers env-var parsing, dir-filtering, arg dedup.

## How the new flow looks

```
snyk test … (env: SNYK_AUTODETECT_OSS=1)
   │
   └─► OSWorkflow
         ├─► managed scan (processAllInputDirectories)  ◄── existing path, unchanged
         └─► detect.HasCPPArtefacts for each input dir
                  │
                  └─► any C/C++ artefacts AND --unmanaged not already set?
                          ├─ no  → return managed data
                          └─ yes → invoke legacycli with --unmanaged injected
                                   append its workflow.Data to managed output
```

## Why off-by-default

Off unless `SNYK_AUTODETECT_OSS` is truthy. Lets us roll out without disturbing existing CLI users: direct `snyk test` against a folder with stray `.cpp` files (e.g. native node modules) keeps behaving exactly as today. snyk-ls opts every OSS scan in via the companion PR.

## Limitation

A Go-native `unmanaged.test` workflow does not yet exist anywhere — the env-var gate in earlier WIP referenced an identifier that was never registered. This PR therefore invokes `legacycli` (TypeScript CLI) for the unmanaged half. The legacy CLI's `workflow.Data` carries its own content type, so for mixed manifest + C/C++ folders the unmanaged and managed results render as **two separate sections** rather than as one unified report. When a native unmanaged workflow lands, the swap is local — just point `invokeLegacyUnmanagedScan` at the new workflow identifier.

## Companion PRs

- [snyk/snyk-ls#1311](https://github.com/snyk/snyk-ls/pull/1311) — flips on `SNYK_AUTODETECT_OSS=1` for every OSS CLI invocation from the LS, and deletes the now-redundant per-folder `snyk_oss_unmanaged_enabled` setting, prompt UX, panel toggle, and re-arm logic.
- [snyk/snyk-intellij-plugin#834](https://github.com/snyk/snyk-intellij-plugin/pull/834) — *closed*; the per-folder setting it forwarded no longer exists.

Jira: [IDE-2089](https://snyk.atlassian.net/browse/IDE-2089)

## Test plan

- [x] `go test ./pkg/unmanaged/detect/... ./internal/commands/ostest/...` — green
- [x] `go test ./...` — full repo green
- [x] `go vet ./...` — clean
- [ ] Manual: `SNYK_AUTODETECT_OSS=1 snyk test` against a folder with both `package.json` and `.cpp` files — confirm both managed and unmanaged results appear.
- [ ] Manual: same env var on a pure-JS folder — confirm only managed output (no spurious unmanaged scan).
- [ ] Manual: env var unset — confirm behaviour unchanged from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IDE-2089]: https://snyksec.atlassian.net/browse/IDE-2089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ