### PR TITLE
fix: emit user-facing warning when reachability upload is skipped

### DIFF
--- a/internal/commands/ostest/depgraph_flow.go
+++ b/internal/commands/ostest/depgraph_flow.go
@@ -34,6 +34,30 @@ const (
 	targetReferenceField     = "targetReference"
 )
 
+func applyReachability(ctx context.Context, orgUUID uuid.UUID, clients common.FlowClients, opts *common.ReachabilityOpts, depGraphs []DepGraphWithMeta) {
+	ictx := cmdctx.Ictx(ctx)
+	logger := cmdctx.Logger(ctx)
+	progressBar := cmdctx.ProgressBar(ctx)
+
+	if !common.ShouldRunReachability(opts.SourceDir, logger) {
+		//nolint:errcheck // Best-effort warning output.
+		ictx.GetUserInterface().OutputError(reachability.NewWarning(errors.New("no reachability-supported source files were found; skipping reachability analysis")))
+		return
+	}
+
+	progressBar.SetTitle(constants.UploadingSourceCodeMessage)
+
+	scanID, err := reachability.GetReachabilityID(ctx, orgUUID, opts.SourceDir, clients.ReachabilityClient, clients.FileUploadClient, clients.DeeproxyClient)
+	if err != nil {
+		logger.Warn().Err(err).Msg("Reachability analysis failed, proceeding without reachability")
+		//nolint:errcheck // Best-effort warning output.
+		ictx.GetUserInterface().OutputError(reachability.NewWarning(err))
+		return
+	}
+
+	enrichWithScanID(depGraphs, &scanID)
+}
+
 func enrichWithScanID(depgraphs []DepGraphWithMeta, reachabilityScanID *reachability.ID) {
 	if reachabilityScanID == nil {
 		return
@@ -97,24 +121,8 @@ func RunUnifiedTestFlow(
 		return nil, nil, err
 	}
 
-	if reachabilityOpts != nil && common.ShouldRunReachability(reachabilityOpts.SourceDir, logger) {
-		progressBar.SetTitle(constants.UploadingSourceCodeMessage)
-
-		scanID, scanErr := reachability.GetReachabilityID(
-			ctx,
-			orgUUID,
-			reachabilityOpts.SourceDir,
-			clients.ReachabilityClient,
-			clients.FileUploadClient,
-			clients.DeeproxyClient,
-		)
-		if scanErr != nil {
-			logger.Warn().Err(scanErr).Msg("Reachability analysis failed, proceeding without reachability")
-			//nolint:errcheck // Best-effort warning output.
-			ictx.GetUserInterface().OutputError(reachability.NewWarning(scanErr))
-		} else {
-			enrichWithScanID(depGraphs, &scanID)
-		}
+	if reachabilityOpts != nil {
+		applyReachability(ctx, orgUUID, clients, reachabilityOpts, depGraphs)
 	}
 	enrichWithIgnorePolicy(depGraphs, cfg.GetBool(flags.FlagIgnorePolicy))
 	enrichWithProjectNameOverride(depGraphs, cfg.GetString(flags.FlagProjectName))

--- a/internal/commands/ostest/depgraph_flow_test.go
+++ b/internal/commands/ostest/depgraph_flow_test.go
@@ -430,6 +430,10 @@ func Test_RunUnifiedTestFlow_SkipsReachabilityWhenNoSupportedSources(t *testing.
 	sourceDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "main.go"), []byte("package main"), 0o600))
 
+	mockUI := gafmocks.NewMockUserInterface(h.ctrl)
+	mockUI.EXPECT().OutputError(gomock.Any()).Return(nil).Times(1)
+	h.ictx.EXPECT().GetUserInterface().Return(mockUI).Times(1)
+
 	// RecordCodeUploadTime is NOT expected — its absence asserts that the
 	// reachability upload path was skipped.
 	h.instr.EXPECT().RecordOSAnalysisTime(gomock.Any()).Times(1)

--- a/internal/commands/ostest/sbom_flow_test.go
+++ b/internal/commands/ostest/sbom_flow_test.go
@@ -533,6 +533,7 @@ func setupTest(
 	mockConfig.Set(configuration.ORGANIZATION_SLUG, orgSlug)
 	mockUI := gafmocks.NewMockUserInterface(ctrl)
 	mockUI.EXPECT().Output(gomock.Any()).Return(nil).Times(0)
+	mockUI.EXPECT().OutputError(gomock.Any()).Return(nil).AnyTimes()
 	mockIctx := gafmocks.NewMockInvocationContext(ctrl)
 	mockIctx.EXPECT().GetConfiguration().Return(mockConfig).AnyTimes()
 	mockIctx.EXPECT().GetEnhancedLogger().Return(&nopLogger).AnyTimes()

--- a/internal/common/dfly_depgraph_flow.go
+++ b/internal/common/dfly_depgraph_flow.go
@@ -14,9 +14,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
 	"github.com/snyk/cli-extension-os-flows/internal/commands/cmdctx"
-	"github.com/snyk/cli-extension-os-flows/internal/constants"
 	"github.com/snyk/cli-extension-os-flows/internal/legacy/definitions"
-	"github.com/snyk/cli-extension-os-flows/internal/reachability"
 	"github.com/snyk/cli-extension-os-flows/pkg/flags"
 )
 
@@ -121,17 +119,9 @@ func RunDflyDepgraphFlow(
 
 	resources := []testapi.TestResourceCreateItem{uploadResource}
 
-	if reachabilityOpts != nil && ShouldRunReachability(reachabilityOpts.SourceDir, logger) {
-		progressBar.SetTitle(constants.UploadingSourceCodeMessage)
-
-		var sourceResource testapi.TestResourceCreateItem
-		sourceResource, err = UploadSourceCodeResource(ctx, orgUUID, clients.FileUploadClient, clients.DeeproxyClient, reachabilityOpts.SourceDir)
-		if err != nil {
-			logger.Warn().Err(err).Msg("Failed to upload source code, proceeding without reachability")
-			//nolint:errcheck // Best-effort warning output.
-			ictx.GetUserInterface().OutputError(reachability.NewWarning(err))
-		} else {
-			resources = append(resources, sourceResource)
+	if reachabilityOpts != nil {
+		if upload := uploadReachabilitySourcesIfAny(ctx, orgUUID, clients, reachabilityOpts); upload != nil {
+			resources = append(resources, *upload)
 		}
 	}
 

--- a/internal/common/dfly_depgraph_flow_test.go
+++ b/internal/common/dfly_depgraph_flow_test.go
@@ -512,6 +512,7 @@ func setupDflyInvocationContext(t *testing.T, ctrl *gomock.Controller, jsonOutpu
 
 	mockUI := gafmocks.NewMockUserInterface(ctrl)
 	mockUI.EXPECT().Output(gomock.Any()).Return(nil).Times(0)
+	mockUI.EXPECT().OutputError(gomock.Any()).Return(nil).AnyTimes()
 
 	mockIctx := gafmocks.NewMockInvocationContext(ctrl)
 	mockIctx.EXPECT().GetConfiguration().Return(fakeConfig).AnyTimes()

--- a/internal/common/reachability.go
+++ b/internal/common/reachability.go
@@ -6,11 +6,13 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
+	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 
 	"github.com/snyk/cli-extension-os-flows/internal/commands/clientsetup"
 	"github.com/snyk/cli-extension-os-flows/internal/commands/cmdctx"
 	"github.com/snyk/cli-extension-os-flows/internal/constants"
+	"github.com/snyk/cli-extension-os-flows/internal/reachability"
 	"github.com/snyk/cli-extension-os-flows/internal/reachability/sources"
 	"github.com/snyk/cli-extension-os-flows/pkg/flags"
 )
@@ -32,6 +34,34 @@ func ShouldRunReachability(sourceDir string, logger *zerolog.Logger) bool {
 			Msg("No reachability-supported source files found; skipping upload")
 	}
 	return hasSources
+}
+
+// uploadReachabilitySourcesIfAny uploads source code for reachability analysis when the
+// source directory contains supported files. Returns the upload resource on success, nil
+// if skipped (no supported files) or if the upload fails; in both nil cases a user-facing
+// warning is emitted via OutputError.
+func uploadReachabilitySourcesIfAny(ctx context.Context, orgUUID uuid.UUID, clients FlowClients, opts *ReachabilityOpts) *testapi.TestResourceCreateItem {
+	ictx := cmdctx.Ictx(ctx)
+	logger := cmdctx.Logger(ctx)
+	progressBar := cmdctx.ProgressBar(ctx)
+
+	if !ShouldRunReachability(opts.SourceDir, logger) {
+		//nolint:errcheck // Best-effort warning output.
+		ictx.GetUserInterface().OutputError(reachability.NewWarning(fmt.Errorf("no reachability-supported source files were found; skipping reachability analysis")))
+		return nil
+	}
+
+	progressBar.SetTitle(constants.UploadingSourceCodeMessage)
+
+	resource, err := UploadSourceCodeResource(ctx, orgUUID, clients.FileUploadClient, clients.DeeproxyClient, opts.SourceDir)
+	if err != nil {
+		logger.Warn().Err(err).Msg("Failed to upload source code, proceeding without reachability")
+		//nolint:errcheck // Best-effort warning output.
+		ictx.GetUserInterface().OutputError(reachability.NewWarning(err))
+		return nil
+	}
+
+	return &resource
 }
 
 // ResolveMonitorReachabilityOpts determines the reachability options for the monitor flow.

--- a/internal/common/sbom_flow.go
+++ b/internal/common/sbom_flow.go
@@ -11,9 +11,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
 	"github.com/snyk/cli-extension-os-flows/internal/commands/cmdctx"
-	"github.com/snyk/cli-extension-os-flows/internal/constants"
 	"github.com/snyk/cli-extension-os-flows/internal/legacy/definitions"
-	"github.com/snyk/cli-extension-os-flows/internal/reachability"
 	"github.com/snyk/cli-extension-os-flows/pkg/flags"
 )
 
@@ -32,7 +30,6 @@ func RunSbomFlow(
 	publishReport *bool,
 	runTest RunTestWithResourcesFunc,
 ) ([]definitions.LegacyVulnerabilityResponse, []workflow.Data, error) {
-	ictx := cmdctx.Ictx(ctx)
 	cfg := cmdctx.Config(ctx)
 	logger := cmdctx.Logger(ctx)
 	progressBar := cmdctx.ProgressBar(ctx)
@@ -68,17 +65,9 @@ func RunSbomFlow(
 
 	resources := []testapi.TestResourceCreateItem{sbomResource}
 
-	if reachabilityOpts != nil && ShouldRunReachability(reachabilityOpts.SourceDir, logger) {
-		progressBar.SetTitle(constants.UploadingSourceCodeMessage)
-
-		var sourceResource testapi.TestResourceCreateItem
-		sourceResource, err = UploadSourceCodeResource(ctx, orgUUID, clients.FileUploadClient, clients.DeeproxyClient, reachabilityOpts.SourceDir)
-		if err != nil {
-			logger.Warn().Err(err).Msg("Failed to upload source code, proceeding without reachability")
-			//nolint:errcheck // Best-effort warning output.
-			ictx.GetUserInterface().OutputError(reachability.NewWarning(err))
-		} else {
-			resources = append(resources, sourceResource)
+	if reachabilityOpts != nil {
+		if upload := uploadReachabilitySourcesIfAny(ctx, orgUUID, clients, reachabilityOpts); upload != nil {
+			resources = append(resources, *upload)
 		}
 	}
 


### PR DESCRIPTION
When `ShouldRunReachability` returns false (no supported source files detected), the upload path is now skipped cleanly — but no feedback was reaching the user.

Previously, attempting the upload with an empty file set caused the API to reject the revision, which produced the error `"failed to upload source code for reachability analysis"` surfaced as a user-facing warning. With the new early-exit gate, that error path is bypassed, taking the warning with it.

This fix adds an `else` branch at all three call sites (`depgraph_flow`, `dfly_depgraph_flow`, `sbom_flow`) that calls `OutputError(reachability.NewWarning(...))` so the user still receives a warning when reachability is silently skipped due to no supported source files.