### PR TITLE
feat(ostest): adds support for html and html-file-output flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/snyk/cli-extension-dep-graph v1.23.0
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90
-	github.com/snyk/go-application-framework v0.1.1-0.20260601153725-33af46ffdfa5
+	github.com/snyk/go-application-framework v0.5.0
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/net v0.55.0

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90 h1:MumWzLKiIFhZEk/wP71S/zv2cceygDb3+KNXGBb1hC0=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.1.1-0.20260601153725-33af46ffdfa5 h1:nuHRhOlISEByoqX8CAERY1t+sZrdy7ksMhZhV0f2yeI=
-github.com/snyk/go-application-framework v0.1.1-0.20260601153725-33af46ffdfa5/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
+github.com/snyk/go-application-framework v0.5.0 h1:9XQyCxzq0bFuHxRC89WXY3AXMHvj5CVQ9njAbdoH3GU=
+github.com/snyk/go-application-framework v0.5.0/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/internal/commands/ostest/workflow.go
+++ b/internal/commands/ostest/workflow.go
@@ -247,6 +247,9 @@ func legacyEntrypoint(ctx context.Context) ([]workflow.Data, error) {
 	return ictx.GetEngine().InvokeWithConfig(workflow.NewWorkflowIdentifier("legacycli"), legacyConfig)
 }
 
+// previewTestFlags lists the flags on `snyk test` that are gated behind GAF's PREVIEW_FEATURES_ENABLED flag.
+var previewTestFlags = []string{flags.FlagHTML, flags.FlagHTMLFileOutput}
+
 // OSWorkflow is the entry point for the Open Source Test workflow.
 func OSWorkflow(
 	ictx workflow.InvocationContext,
@@ -266,6 +269,11 @@ func OSWorkflow(
 
 	//nolint:wrapcheck // Validation errors are coming from the error catalog.
 	if err := validation.ValidateFlagValues(cfg, validation.CommandTest); err != nil {
+		return nil, err
+	}
+
+	//nolint:wrapcheck // Preview-gate errors are coming from the error catalog.
+	if err := validation.ValidatePreviewFlags(cfg, previewTestFlags...); err != nil {
 		return nil, err
 	}
 

--- a/internal/commands/ostest/workflow_test.go
+++ b/internal/commands/ostest/workflow_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
+	snyk_errors "github.com/snyk/error-catalog-golang-public/snyk_errors"
 	"github.com/snyk/go-application-framework/pkg/analytics"
 	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
 	"github.com/snyk/go-application-framework/pkg/configuration"
@@ -75,6 +76,84 @@ func TestOSWorkflow_LegacyFlow(t *testing.T) {
 
 	// Verify
 	assert.NoError(t, err)
+}
+
+// TestOSWorkflow_PreviewGate verifies that --html / --html-file-output are
+// rejected before any flow runs unless preview features are enabled.
+func TestOSWorkflow_PreviewGate(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupConfig    func(config configuration.Configuration, htmlFilePath string)
+		previewEnabled bool
+		errorContains  string
+	}{
+		{
+			name: "html without preview is rejected",
+			setupConfig: func(config configuration.Configuration, _ string) {
+				config.Set(flags.FlagHTML, true)
+			},
+			errorContains: "--html is a preview feature and is not available in this release.",
+		},
+		{
+			name: "html-file-output without preview is rejected",
+			setupConfig: func(config configuration.Configuration, htmlFilePath string) {
+				config.Set(flags.FlagHTMLFileOutput, htmlFilePath)
+			},
+			errorContains: "--html-file-output is a preview feature and is not available in this release.",
+		},
+		{
+			name: "html with preview passes the gate",
+			setupConfig: func(config configuration.Configuration, _ string) {
+				config.Set(flags.FlagHTML, true)
+			},
+			previewEnabled: true,
+		},
+		{
+			name: "html-file-output with preview passes the gate",
+			setupConfig: func(config configuration.Configuration, htmlFilePath string) {
+				config.Set(flags.FlagHTMLFileOutput, htmlFilePath)
+			},
+			previewEnabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockEngine := mocks.NewMockEngine(ctrl)
+			mockInvocationCtx := createMockInvocationCtxWithURL(t, ctrl, mockEngine, "")
+			config := mockInvocationCtx.GetConfiguration()
+
+			htmlFilePath := filepath.Join(t.TempDir(), "report.html")
+			tt.setupConfig(config, htmlFilePath)
+			config.Set(configuration.PREVIEW_FEATURES_ENABLED, tt.previewEnabled)
+
+			if tt.previewEnabled {
+				// The gate passes and the default config routes to the legacy flow.
+				mockEngine.EXPECT().
+					InvokeWithConfig(legacyWorkflowID, gomock.Any()).
+					Return([]workflow.Data{}, nil).
+					Times(1)
+			}
+			// For rejection cases, no engine invocation is expected;
+			// ctrl.Finish fails the test if any flow is invoked.
+
+			_, err := ostest.OSWorkflow(mockInvocationCtx, []workflow.Data{})
+
+			if tt.errorContains != "" {
+				require.Error(t, err)
+				var catalogErr snyk_errors.Error
+				require.ErrorAs(t, err, &catalogErr)
+				assert.Equal(t, "SNYK-CLI-0014", catalogErr.ErrorCode)
+				assert.Contains(t, catalogErr.Detail, tt.errorContains)
+				assert.NoFileExists(t, htmlFilePath, "rejected run must not write an HTML file")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestOSWorkflow_OrgIDHandling(t *testing.T) {

--- a/internal/legacy/validation/validation.go
+++ b/internal/legacy/validation/validation.go
@@ -31,6 +31,35 @@ func isEmptyFlagValue(v string) bool {
 	return v == "" || v == flags.InvalidFlagValue
 }
 
+// ValidatePreviewFlags returns an error if any of the named flags are in use
+// while configuration.PREVIEW_FEATURES_ENABLED is not set.
+func ValidatePreviewFlags(cfg configuration.Configuration, previewFlagNames ...string) error {
+	if cfg.GetBool(configuration.PREVIEW_FEATURES_ENABLED) {
+		return nil
+	}
+	for _, name := range previewFlagNames {
+		if flagInUse(cfg, name) {
+			return snyk_cli_errors.NewFeatureUnderDevelopmentError("--" + name + " is a preview feature and is not available in this release.")
+		}
+	}
+	return nil
+}
+
+// flagInUse reports whether a flag is actively in use.
+func flagInUse(cfg configuration.Configuration, name string) bool {
+	if !cfg.IsSet(name) {
+		return false
+	}
+	switch v := cfg.Get(name).(type) {
+	case bool:
+		return v
+	case string:
+		return v != ""
+	default:
+		return true
+	}
+}
+
 // ValidateFlagValues applies legacy-compat business rules for test and monitor flag values.
 // command is the workflow command name; only CommandTest allows --json-file-output and --sarif-file-output.
 // It returns an error if any rule is violated.
@@ -54,6 +83,9 @@ func ValidateFlagValues(cfg configuration.Configuration, command Command) error 
 		return err
 	}
 	if err := validateSarifFileOutput(cfg); err != nil {
+		return err
+	}
+	if err := validateHTMLFileOutput(cfg); err != nil {
 		return err
 	}
 	if err := validateProjectBusinessCriticality(cfg); err != nil {
@@ -152,6 +184,16 @@ func validateSarifFileOutput(cfg configuration.Configuration) error {
 	}
 	if isEmptyFlagValue(cfg.GetString(outputworkflow.OutputConfigKeySarifFileOutput)) {
 		return snyk_cli_errors.NewEmptyFlagOptionError("Empty --sarif-file-output argument. Did you mean --file=path/to/output-file.json ?")
+	}
+	return nil
+}
+
+func validateHTMLFileOutput(cfg configuration.Configuration) error {
+	if !cfg.IsSet(flags.FlagHTMLFileOutput) {
+		return nil
+	}
+	if isEmptyFlagValue(cfg.GetString(flags.FlagHTMLFileOutput)) {
+		return snyk_cli_errors.NewEmptyFlagOptionError("Empty --html-file-output argument. Did you mean --file=path/to/output-file.html ?")
 	}
 	return nil
 }

--- a/internal/legacy/validation/validation_test.go
+++ b/internal/legacy/validation/validation_test.go
@@ -17,10 +17,12 @@ import (
 // Expected catalog Title and ErrorCode for errors from cli.NewInvalidFlagOptionError and cli.NewEmptyFlagOptionError.
 // These must match github.com/snyk/error-catalog-golang-public/cli (see snyk_errors.Error struct: Title, ErrorCode, Detail).
 const (
-	catalogErrorCodeInvalidFlagOption = "SNYK-CLI-0004"
-	catalogErrorCodeEmptyFlagOption   = "SNYK-CLI-0003"
-	catalogTitleInvalidFlagOption     = "Invalid flag option"
-	catalogTitleEmptyFlagOption       = "Empty flag option"
+	catalogErrorCodeInvalidFlagOption       = "SNYK-CLI-0004"
+	catalogErrorCodeEmptyFlagOption         = "SNYK-CLI-0003"
+	catalogErrorCodeFeatureUnderDevelopment = "SNYK-CLI-0014"
+	catalogTitleInvalidFlagOption           = "Invalid flag option"
+	catalogTitleEmptyFlagOption             = "Empty flag option"
+	catalogTitleFeatureUnderDevelopment     = "Feature under development"
 )
 
 // assertCatalogError asserts that err is a catalog error with the expected ErrorCode, Title, and Detail.
@@ -338,4 +340,78 @@ func TestValidateFlagValues_ProjectTags_EmptyWhenSet(t *testing.T) {
 			"--project-tags must contain an '=' with a comma-separated list of pairs (also separated with an '=')."+
 				" To clear all existing values, pass no values i.e. --project-tags=")
 	})
+}
+
+func TestValidatePreviewFlags(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		htmlSet           bool
+		htmlFileOutputSet bool
+		previewEnabled    bool
+		shouldErr         bool
+		expectedDetail    string
+	}{
+		{
+			name: "no error when no preview flags are in use",
+		},
+		{
+			name:           "no error when only preview is enabled",
+			previewEnabled: true,
+		},
+		{
+			name:           "error when html set without preview",
+			htmlSet:        true,
+			shouldErr:      true,
+			expectedDetail: "--html is a preview feature and is not available in this release.",
+		},
+		{
+			name:              "error when html-file-output set without preview",
+			htmlFileOutputSet: true,
+			shouldErr:         true,
+			expectedDetail:    "--html-file-output is a preview feature and is not available in this release.",
+		},
+		{
+			name:           "no error when html set with preview enabled",
+			htmlSet:        true,
+			previewEnabled: true,
+		},
+		{
+			name:              "no error when html-file-output set with preview enabled",
+			htmlFileOutputSet: true,
+			previewEnabled:    true,
+		},
+		{
+			name:              "no error when both set with preview enabled",
+			htmlSet:           true,
+			htmlFileOutputSet: true,
+			previewEnabled:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := configuration.New()
+			if tc.htmlSet {
+				cfg.Set(flags.FlagHTML, true)
+			}
+			if tc.htmlFileOutputSet {
+				cfg.Set(flags.FlagHTMLFileOutput, "/tmp/report.html")
+			}
+			if tc.previewEnabled {
+				cfg.Set(configuration.PREVIEW_FEATURES_ENABLED, true)
+			}
+
+			err := validation.ValidatePreviewFlags(cfg, flags.FlagHTML, flags.FlagHTMLFileOutput)
+
+			if !tc.shouldErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assertCatalogError(t, err, catalogErrorCodeFeatureUnderDevelopment, catalogTitleFeatureUnderDevelopment, tc.expectedDetail)
+		})
+	}
 }

--- a/internal/outputworkflow/findings_model_tools.go
+++ b/internal/outputworkflow/findings_model_tools.go
@@ -153,8 +153,8 @@ func getDefaultWriter(config configuration.Configuration, outputDestination Outp
 		renderEmptyData: true,
 	}
 
-	// disable default loca writer if sarif is enabled which basically delegates the sarif writing to the global renderer
-	if config.GetBool(output_workflow.OUTPUT_CONFIG_KEY_SARIF) {
+	// disable default local writer if sarif or html is enabled which basically delegates the writing to the global renderer
+	if config.GetBool(output_workflow.OUTPUT_CONFIG_KEY_SARIF) || config.GetBool(output_workflow.OUTPUT_CONFIG_KEY_HTML) {
 		return nil
 	}
 

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -79,6 +79,10 @@ const (
 	// Output file flags (used by test and validation).
 	FlagJSONFileOutput  = "json-file-output"
 	FlagSarifFileOutput = "sarif-file-output"
+
+	// HTML output flags.
+	FlagHTML           = "html"
+	FlagHTMLFileOutput = "html-file-output"
 )
 
 // OSTestFlagSet returns a flag set for the Open Source Test workflow.
@@ -105,6 +109,11 @@ func OSTestFlagSet() *pflag.FlagSet {
 	}
 	flagSet.String(FlagSarifFileOutput, "", "Write SARIF output to a file.")
 	if f := flagSet.Lookup(FlagSarifFileOutput); f != nil {
+		f.NoOptDefVal = InvalidFlagValue
+	}
+	flagSet.Bool(FlagHTML, false, "Print HTML output to console.")
+	flagSet.String(FlagHTMLFileOutput, "", "Write HTML output to a file.")
+	if f := flagSet.Lookup(FlagHTMLFileOutput); f != nil {
 		f.NoOptDefVal = InvalidFlagValue
 	}
 

--- a/pkg/flags/flags_test.go
+++ b/pkg/flags/flags_test.go
@@ -69,6 +69,36 @@ func TestReachabilityFlag(t *testing.T) {
 	}
 }
 
+func TestHTMLFlags(t *testing.T) {
+	t.Run("html flag parses as bool", func(t *testing.T) {
+		flagSet := flags.OSTestFlagSet()
+		err := flagSet.Parse([]string{"--html"})
+		require.NoError(t, err, "flag parsing should not fail")
+
+		html, err := flagSet.GetBool(flags.FlagHTML)
+		require.NoError(t, err, "getting flag value should not fail")
+		assert.Equal(t, true, html)
+	})
+
+	t.Run("html-file-output flag parses as string", func(t *testing.T) {
+		flagSet := flags.OSTestFlagSet()
+		err := flagSet.Parse([]string{"--html-file-output=report.html"})
+		require.NoError(t, err, "flag parsing should not fail")
+
+		value, err := flagSet.GetString(flags.FlagHTMLFileOutput)
+		require.NoError(t, err, "getting flag value should not fail")
+		assert.Equal(t, "report.html", value)
+	})
+
+	t.Run("html flags are registered on OSTestFlagSet", func(t *testing.T) {
+		flagSet := flags.OSTestFlagSet()
+
+		for _, name := range []string{flags.FlagHTML, flags.FlagHTMLFileOutput} {
+			assert.NotNil(t, flagSet.Lookup(name), "--%s should be registered on OSTestFlagSet", name)
+		}
+	})
+}
+
 func TestRemoteRepoURLFlag(t *testing.T) {
 	flagSets := []struct {
 		name     string


### PR DESCRIPTION
This PR adds the `--html` and `--html-file-output` flags gated behind the `PREVIEW_FEATURES_ENABLED` config in preparation for HTML rendering via https://github.com/snyk/go-application-framework/pull/625

`--html` and `--html-file-output` should only work when `PREVIEW_FEATURES_ENABLED` is true - e.g. on CLI preview or locally built binaries. It will return `SNYK-CLI-0014` otherwise