### PR TITLE
feat: bump cli-exntenstion-dep-graph

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/muesli/termenv v0.16.0
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/rs/zerolog v1.34.0
-	github.com/snyk/cli-extension-dep-graph v1.23.0
+	github.com/snyk/cli-extension-dep-graph/v2 v2.6.0
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90
 	github.com/snyk/go-application-framework v0.1.1-0.20260601153725-33af46ffdfa5
@@ -81,6 +81,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.20 // indirect
 	github.com/onsi/gomega v1.38.0 // indirect
+	github.com/package-url/packageurl-go v0.1.3 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
@@ -120,4 +121,4 @@ require (
 )
 
 // replace github.com/snyk/go-application-framework => ../go-application-framework
-// replace github.com/snyk/cli-extension-dep-graph => ../cli-extension-dep-graph
+// replace github.com/snyk/cli-extension-dep-graph/v2 => ../cli-extension-dep-graph

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,8 @@ github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmt
 github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/onsi/gomega v1.38.0 h1:c/WX+w8SLAinvuKKQFh77WEucCnPk4j2OTUr7lt7BeY=
 github.com/onsi/gomega v1.38.0/go.mod h1:OcXcwId0b9QsE7Y49u+BTrL4IdKOBOKnD6VQNTJEB6o=
+github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
+github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
@@ -200,8 +202,8 @@ github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
-github.com/snyk/cli-extension-dep-graph v1.23.0 h1:Hg9+hKu/bQeaacibdBz1IEXhRtDRda0z23vbRvmZDDI=
-github.com/snyk/cli-extension-dep-graph v1.23.0/go.mod h1:TLHZKbfd1hv5jkGZ2uhV4DNQIvXJgjgQsPnqu0xAWW8=
+github.com/snyk/cli-extension-dep-graph/v2 v2.6.0 h1:tv21E++s5tVF8L54fJ485Grb9jo14lE3ubT3cXPHN3k=
+github.com/snyk/cli-extension-dep-graph/v2 v2.6.0/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/code-client-go v1.24.5 h1:ySsfTeaNmi3nWSuM3YaVIiSAG+H/ikD2hACxqneIZJw=
 github.com/snyk/code-client-go v1.24.5/go.mod h1:YYggK3UbOHl5rg7uBhLzsKZBFNavcwFUse/EWCKWdzw=
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3YKLR5LJbqL8WJmUYgDSbFKREIY79g0=

--- a/internal/commands/ostest/routing.go
+++ b/internal/commands/ostest/routing.go
@@ -7,8 +7,8 @@ import (
 	"os"
 
 	"github.com/google/uuid"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/orchestrator"
-	uvutils "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/uv"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/orchestrator"
+	uvutils "github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/python/uv"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 
 	"github.com/snyk/cli-extension-os-flows/internal/commands/cmdctx"

--- a/internal/commands/ostest/routing_test.go
+++ b/internal/commands/ostest/routing_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/orchestrator"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/orchestrator"
 	snyk_errors "github.com/snyk/error-catalog-golang-public/snyk_errors"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/stretchr/testify/assert"

--- a/internal/commands/ostest/workflow.go
+++ b/internal/commands/ostest/workflow.go
@@ -15,7 +15,7 @@ import (
 	"os"
 
 	"github.com/google/uuid"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/orchestrator"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/orchestrator"
 
 	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
 	"github.com/snyk/go-application-framework/pkg/configuration"

--- a/internal/common/depgraph.go
+++ b/internal/common/depgraph.go
@@ -10,9 +10,9 @@ import (
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 
 	"github.com/rs/zerolog"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/orchestrator"
-	uvutils "github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/python/uv"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/orchestrator"
+	uvutils "github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/python/uv"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 

--- a/internal/common/depgraph_internal_test.go
+++ b/internal/common/depgraph_internal_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/common/depgraph_resolver.go
+++ b/internal/common/depgraph_resolver.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems"
-	"github.com/snyk/cli-extension-dep-graph/pkg/ecosystems/orchestrator"
-	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems/orchestrator"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/workflow"

--- a/internal/common/depgraph_resolver_test.go
+++ b/internal/common/depgraph_resolver_test.go
@@ -3,7 +3,7 @@ package common_test
 import (
 	"testing"
 
-	"github.com/snyk/cli-extension-dep-graph/pkg/identity"
+	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Bumps cli-extension-dep-graph from `v1.23.0` to `v2.6.0`, which includes the new Cargo, Gradle and Rush resolvers.

The dep-graph repo migrated its Go module path to /v2 as part of this work, so this PR updates the module path in go.mod and all import paths across the 7 affected Go files in addition to the version bump.

What's included in v2.6.0:
- Native Cargo resolver (internal-cargo-resolver feature flag)
- Native Gradle resolver with dependency normalisation (internal-new-gradle-resolver feature flag)
- Rush resolver (internal-pnpm-resolver feature flag)
- Go module path migration from github.com/snyk/cli-extension-dep-graph → github.com/snyk/cli-extension-dep-graph/v2

Both resolvers are behind feature flags and off by default — no behaviour change for existing users until the flags are enabled per org.