### PR TITLE
chore: bump go to 1.26.4 and x/crypto to v0.52.0 [UNIFY-1406]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   unit-test:
     executor:
       name: go/default
-      tag: "1.26.3"
+      tag: "1.26.4"
     steps:
       - checkout
       - go/load-cache
@@ -23,7 +23,7 @@ jobs:
   integration-test:
     executor:
       name: go/default
-      tag: "1.26.3"
+      tag: "1.26.4"
     steps:
       - checkout
       - go/load-cache
@@ -43,7 +43,7 @@ jobs:
   security-scans:
     executor:
       name: go/default
-      tag: "1.26.3"
+      tag: "1.26.4"
     resource_class: small
     steps:
       - checkout

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 nodejs 20.19.5
-golang 1.26.3
+golang 1.26.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/cli-extension-os-flows
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -113,7 +113,7 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
-	golang.org/x/crypto v0.51.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
-golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=


### PR DESCRIPTION
Resolves [UNIFY-1406](https://snyksec.atlassian.net/browse/UNIFY-1406).

Addresses high-severity vulnerabilities:

- **golang.org/x/crypto v0.51.0 → v0.52.0**: CVE-2026-46597, CVE-2026-39835, CVE-2026-39831, CVE-2026-39827, CVE-2026-46598, CVE-2026-42508
- **go 1.26.3 → 1.26.4**: CVE-2026-27145 (std/crypto/x509), CVE-2026-42504 (std/mime)

### Verification

- `go build ./...` clean
- `make test` — 872 tests pass
- `snyk test --file=go.mod --severity-threshold=high` — no vulnerable paths found

[UNIFY-1406]: https://snyksec.atlassian.net/browse/UNIFY-1406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ