### PR TITLE
Split snyk sbom test results by component [OSF-294]

### DIFF
--- a/internal/commands/ostest/consolidation_test.go
+++ b/internal/commands/ostest/consolidation_test.go
@@ -1,6 +1,7 @@
 package ostest_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -11,6 +12,7 @@ import (
 	"github.com/snyk/cli-extension-os-flows/internal/commands/cmdctx"
 	"github.com/snyk/cli-extension-os-flows/internal/commands/ostest"
 	"github.com/snyk/cli-extension-os-flows/internal/presenters"
+	"github.com/snyk/cli-extension-os-flows/internal/util"
 	"github.com/snyk/cli-extension-os-flows/internal/util/testfactories"
 )
 
@@ -313,6 +315,77 @@ func Test_formatPathsCount(t *testing.T) {
 	t.Run("returns plural for multiple paths", func(t *testing.T) {
 		result := presenters.FormatPathsCount([]string{"path1", "path2", "path3"})
 		assert.Contains(t, result, "2 other paths")
+	})
+}
+
+func Test_consolidateFindingsByComponent(t *testing.T) {
+	logger := zerolog.Nop()
+	newCtx := func() context.Context {
+		ctx := t.Context()
+		ctx = cmdctx.WithLogger(ctx, &logger)
+		ctx = cmdctx.WithProgressBar(ctx, &nopProgressBar)
+		return ctx
+	}
+
+	const (
+		compA = "pkg:npm/app-a@1.0.0"
+		compB = "pkg:npm/app-b@2.0.0"
+	)
+
+	findingFor := func(component, snykID string, sev testapi.Severity) testapi.FindingData {
+		return testapi.FindingData{
+			Attributes: &testapi.FindingAttributes{
+				Rating:       testapi.Rating{Severity: sev},
+				ComponentKey: util.Ptr(component),
+				Problems:     []testapi.Problem{createSnykVulnProblem(snykID)},
+			},
+		}
+	}
+
+	t.Run("reports a shared vulnerability under each component", func(t *testing.T) {
+		findings := []testapi.FindingData{
+			findingFor(compA, "SNYK-TEST-001", testapi.SeverityHigh),
+			findingFor(compB, "SNYK-TEST-001", testapi.SeverityHigh),
+		}
+
+		consolidated, err := ostest.ConsolidateFindingsByComponent(newCtx(), findings)
+		require.NoError(t, err)
+		require.Len(t, consolidated, 2)
+		require.NotNil(t, consolidated[0].Attributes.ComponentKey)
+		require.NotNil(t, consolidated[1].Attributes.ComponentKey)
+		assert.Equal(t, compA, *consolidated[0].Attributes.ComponentKey)
+		assert.Equal(t, compB, *consolidated[1].Attributes.ComponentKey)
+	})
+
+	t.Run("consolidates duplicates within a component and preserves component order", func(t *testing.T) {
+		findings := []testapi.FindingData{
+			findingFor(compA, "SNYK-TEST-001", testapi.SeverityHigh),
+			findingFor(compB, "SNYK-TEST-002", testapi.SeverityMedium),
+			findingFor(compA, "SNYK-TEST-001", testapi.SeverityCritical), // duplicate within compA
+		}
+
+		consolidated, err := ostest.ConsolidateFindingsByComponent(newCtx(), findings)
+		require.NoError(t, err)
+		require.Len(t, consolidated, 2)
+
+		// compA group comes first (first-seen order) with its duplicate merged and highest severity kept.
+		require.NotNil(t, consolidated[0].Attributes.ComponentKey)
+		assert.Equal(t, compA, *consolidated[0].Attributes.ComponentKey)
+		assert.Equal(t, testapi.SeverityCritical, consolidated[0].Attributes.Rating.Severity)
+
+		require.NotNil(t, consolidated[1].Attributes.ComponentKey)
+		assert.Equal(t, compB, *consolidated[1].Attributes.ComponentKey)
+	})
+
+	t.Run("a single component behaves like global consolidation", func(t *testing.T) {
+		findings := []testapi.FindingData{
+			findingFor(compA, "SNYK-TEST-001", testapi.SeverityHigh),
+			findingFor(compA, "SNYK-TEST-001", testapi.SeverityHigh),
+		}
+
+		consolidated, err := ostest.ConsolidateFindingsByComponent(newCtx(), findings)
+		require.NoError(t, err)
+		require.Len(t, consolidated, 1)
 	})
 }
 

--- a/internal/commands/ostest/test_execution.go
+++ b/internal/commands/ostest/test_execution.go
@@ -111,6 +111,14 @@ func runTestInternal(
 		return nil, nil, fmt.Errorf("failed to consolidate findings: %w", err)
 	}
 
+	// Findings for the human-readable output are consolidated per component so a vulnerability
+	// shared across multiple SBOM components is reported under each one. For a single component
+	// (or findings without a component key) this is identical to the global consolidation above.
+	humanReadableFindings, err := ConsolidateFindingsByComponent(ctx, allFindingsData)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to consolidate findings by component: %w", err)
+	}
+
 	// The summary is always needed for the exit code calculation.
 	standardSummary, summaryData, summaryErr := NewSummaryDataFromFindings(consolidatedFindings, targetDir)
 	if summaryErr != nil {
@@ -155,7 +163,7 @@ func runTestInternal(
 		Logger:             logger,
 	}
 
-	return prepareOutput(ctx, consolidatedFindings, standardSummary, summaryData, legacyParams, vulnerablePathsCount)
+	return prepareOutput(ctx, humanReadableFindings, standardSummary, summaryData, legacyParams, vulnerablePathsCount)
 }
 
 func getTestProjectID(result testapi.TestResult) (*string, error) {
@@ -537,6 +545,26 @@ func ConsolidateFindings(ctx context.Context, findings []testapi.FindingData) ([
 	return result, nil
 }
 
+// ConsolidateFindingsByComponent groups findings by their component
+// (testapi.FindingData.Attributes.ComponentKey) and consolidates within each group,
+// concatenating the results in component order. This keeps the component association
+// intact so a finding shared across multiple components is reported under each one.
+// When fewer than two distinct components are present, this is equivalent to
+// ConsolidateFindings over the whole set.
+func ConsolidateFindingsByComponent(ctx context.Context, findings []testapi.FindingData) ([]testapi.FindingData, error) {
+	groups := presenters.GroupFindingsByComponent(findings)
+
+	result := make([]testapi.FindingData, 0, len(findings))
+	for _, group := range groups {
+		consolidated, err := ConsolidateFindings(ctx, group.Findings)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, consolidated...)
+	}
+	return result, nil
+}
+
 func consolidateFindingFix(existing, additional testapi.FindingData, pkgManager string) (*testapi.FindingData, error) {
 	if additional.Relationships == nil || additional.Relationships.Fix == nil {
 		return &existing, nil
@@ -705,6 +733,7 @@ func consolidateFindingAttributes(existing, additional testapi.FindingData, seve
 	} else if result.Attributes != nil {
 		result.Attributes = &testapi.FindingAttributes{
 			CauseOfFailure: result.Attributes.CauseOfFailure,
+			ComponentKey:   result.Attributes.ComponentKey,
 			Description:    result.Attributes.Description,
 			Evidence:       make([]testapi.Evidence, len(result.Attributes.Evidence)),
 			FindingType:    result.Attributes.FindingType,

--- a/internal/presenters/__snapshots__/presenter_unified_finding_test.snap
+++ b/internal/presenters/__snapshots__/presenter_unified_finding_test.snap
@@ -169,3 +169,45 @@ Testing another-project (requirements.txt) ...
 │   Total issues: 0                   │
 ╰─────────────────────────────────────╯
 ---
+
+[TestUnifiedFindingPresenter_MultipleComponents_GroupsByComponent - 1]
+
+Testing my-sbom.json ...
+
+Component: pkg:npm/app-a@1.0.0
+Security issues: 2
+
+ ✗ [MEDIUM] issue in pkg:npm/app-a@1.0.0
+   Finding ID: 00000000-0000-0000-0000-0000000000a2
+   Risk Score: N/A
+
+ ✗ [CRITICAL] issue in pkg:npm/app-a@1.0.0
+   Finding ID: 00000000-0000-0000-0000-0000000000a1
+   Risk Score: N/A
+
+
+Component: pkg:npm/app-b@2.0.0
+Security issues: 1
+
+ ✗ [HIGH] issue in pkg:npm/app-b@2.0.0
+   Finding ID: 00000000-0000-0000-0000-0000000000b1
+   Risk Score: N/A
+
+
+╭─────────────────────────────────────────────────────────╮
+│ Test Summary                                            │
+│                                                         │
+│   Organization:                                         │
+│   Test type:         open-source                        │
+│   Project path:                                         │
+│                                                         │
+│   Total security issues: 3                              │
+│   Ignored: 0 [ 0 CRITICAL  0 HIGH  0 MEDIUM  0 LOW ]    │
+│   Open   : 3 [ 1 CRITICAL  1 HIGH  1 MEDIUM  0 LOW ]    │
+╰─────────────────────────────────────────────────────────╯
+💡 Tip
+
+   To view ignored issues, use the --include-ignores option.
+                                                            
+
+---

--- a/internal/presenters/funcs.go
+++ b/internal/presenters/funcs.go
@@ -450,6 +450,7 @@ func getCliTemplateFuncMap(tmpl *template.Template) template.FuncMap {
 	fnMap["collectAllFindings"] = collectAllFindings
 	fnMap["summaryData"] = summaryData
 	fnMap["shouldShowAggregateSummary"] = shouldShowAggregateSummary
+	fnMap["groupFindingsByComponent"] = GroupFindingsByComponent
 	return fnMap
 }
 
@@ -485,6 +486,52 @@ func collectAllFindings(results []*UnifiedProjectResult) []testapi.FindingData {
 // based on the number of results.
 func shouldShowAggregateSummary(results []*UnifiedProjectResult) bool {
 	return len(results) > 1
+}
+
+// ComponentGroup groups findings by the component they originate from.
+type ComponentGroup struct {
+	// Component is the component key the findings belong to. It is empty when the
+	// findings should be rendered as a single flat list without a component header.
+	Component string
+	Findings  []testapi.FindingData
+}
+
+// GroupFindingsByComponent groups findings by their component key
+// (testapi.FindingData.Attributes.ComponentKey), preserving first-seen order.
+//
+// When there are fewer than two distinct non-empty component keys, a single group
+// with an empty Component is returned so callers render the findings as a flat list,
+// preserving the pre-existing single-component behaviour. Findings without a component
+// key are kept in their own (empty-key) group, rendered without a header.
+func GroupFindingsByComponent(findings []testapi.FindingData) []ComponentGroup {
+	var order []string
+	grouped := map[string][]testapi.FindingData{}
+	for _, f := range findings {
+		key := ""
+		if f.Attributes != nil && f.Attributes.ComponentKey != nil {
+			key = *f.Attributes.ComponentKey
+		}
+		if _, ok := grouped[key]; !ok {
+			order = append(order, key)
+		}
+		grouped[key] = append(grouped[key], f)
+	}
+
+	distinct := 0
+	for _, k := range order {
+		if k != "" {
+			distinct++
+		}
+	}
+	if distinct < 2 {
+		return []ComponentGroup{{Component: "", Findings: findings}}
+	}
+
+	groups := make([]ComponentGroup, 0, len(order))
+	for _, k := range order {
+		groups = append(groups, ComponentGroup{Component: k, Findings: grouped[k]})
+	}
+	return groups
 }
 
 // getDefaultTemplateFuncMap returns the default template function map.

--- a/internal/presenters/funcs_test.go
+++ b/internal/presenters/funcs_test.go
@@ -1,0 +1,70 @@
+package presenters_test
+
+import (
+	"testing"
+
+	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-os-flows/internal/presenters"
+	"github.com/snyk/cli-extension-os-flows/internal/util"
+)
+
+func TestGroupFindingsByComponent(t *testing.T) {
+	findingWithKey := func(key string) testapi.FindingData {
+		return testapi.FindingData{Attributes: &testapi.FindingAttributes{ComponentKey: util.Ptr(key)}}
+	}
+	findingWithoutKey := func() testapi.FindingData {
+		return testapi.FindingData{Attributes: &testapi.FindingAttributes{}}
+	}
+
+	t.Run("empty input returns a single flat group", func(t *testing.T) {
+		groups := presenters.GroupFindingsByComponent(nil)
+		require.Len(t, groups, 1)
+		assert.Empty(t, groups[0].Component)
+		assert.Empty(t, groups[0].Findings)
+	})
+
+	t.Run("a single distinct component renders as a flat group", func(t *testing.T) {
+		findings := []testapi.FindingData{findingWithKey("comp-a"), findingWithKey("comp-a")}
+		groups := presenters.GroupFindingsByComponent(findings)
+		require.Len(t, groups, 1)
+		assert.Empty(t, groups[0].Component, "fewer than two components should not surface a header")
+		assert.Equal(t, findings, groups[0].Findings)
+	})
+
+	t.Run("findings without a component key render as a flat group", func(t *testing.T) {
+		findings := []testapi.FindingData{findingWithoutKey(), findingWithoutKey()}
+		groups := presenters.GroupFindingsByComponent(findings)
+		require.Len(t, groups, 1)
+		assert.Empty(t, groups[0].Component)
+	})
+
+	t.Run("multiple components are grouped in first-seen order", func(t *testing.T) {
+		findings := []testapi.FindingData{
+			findingWithKey("comp-b"),
+			findingWithKey("comp-a"),
+			findingWithKey("comp-b"),
+		}
+		groups := presenters.GroupFindingsByComponent(findings)
+		require.Len(t, groups, 2)
+		assert.Equal(t, "comp-b", groups[0].Component)
+		assert.Len(t, groups[0].Findings, 2)
+		assert.Equal(t, "comp-a", groups[1].Component)
+		assert.Len(t, groups[1].Findings, 1)
+	})
+
+	t.Run("keyless findings form an empty-component group alongside keyed components", func(t *testing.T) {
+		findings := []testapi.FindingData{
+			findingWithKey("comp-a"),
+			findingWithoutKey(),
+			findingWithKey("comp-b"),
+		}
+		groups := presenters.GroupFindingsByComponent(findings)
+		require.Len(t, groups, 3)
+		assert.Equal(t, "comp-a", groups[0].Component)
+		assert.Empty(t, groups[1].Component)
+		assert.Equal(t, "comp-b", groups[2].Component)
+	})
+}

--- a/internal/presenters/presenter_unified_finding_test.go
+++ b/internal/presenters/presenter_unified_finding_test.go
@@ -1357,6 +1357,96 @@ func TestUnifiedFindingPresenter_MultipleProjects_ShouldShowAggregateSummary(t *
 	assert.Equal(t, 4, strings.Count(output, "Test Summary"))
 }
 
+func TestUnifiedFindingPresenter_MultipleComponents_GroupsByComponent(t *testing.T) {
+	config := configuration.New()
+	buffer := &bytes.Buffer{}
+	lipgloss.SetColorProfile(termenv.Ascii)
+
+	const (
+		compA = "pkg:npm/app-a@1.0.0"
+		compB = "pkg:npm/app-b@2.0.0"
+	)
+
+	findingFor := func(id, component string, sev testapi.Severity) testapi.FindingData {
+		return testapi.FindingData{
+			Id:   util.Ptr(uuid.MustParse(id)),
+			Type: util.Ptr(testapi.Findings),
+			Attributes: &testapi.FindingAttributes{
+				Title:        "issue in " + component,
+				Rating:       testapi.Rating{Severity: sev},
+				ComponentKey: util.Ptr(component),
+			},
+		}
+	}
+
+	results := []*presenters.UnifiedProjectResult{
+		{
+			Findings: []testapi.FindingData{
+				findingFor("00000000-0000-0000-0000-0000000000a1", compA, testapi.SeverityCritical),
+				findingFor("00000000-0000-0000-0000-0000000000b1", compB, testapi.SeverityHigh),
+				findingFor("00000000-0000-0000-0000-0000000000a2", compA, testapi.SeverityMedium),
+			},
+			TargetDirectory:   "my-sbom.json",
+			DisplayTargetFile: "",
+			Summary: &json_schemas.TestSummary{
+				Type:             "open-source",
+				SeverityOrderAsc: []string{"low", "medium", "high", "critical"},
+			},
+		},
+	}
+
+	presenter := presenters.NewUnifiedFindingsRenderer(results, config, buffer)
+	err := presenter.RenderTemplate(presenters.DefaultTemplateFiles, presenters.DefaultMimeType)
+	require.NoError(t, err)
+
+	output := buffer.String()
+	assert.Contains(t, output, "Component: "+compA)
+	assert.Contains(t, output, "Component: "+compB)
+	// First-seen order: component A is rendered before component B.
+	assert.Less(t, strings.Index(output, "Component: "+compA), strings.Index(output, "Component: "+compB))
+	// Each component renders its own "Security issues" section (two findings under A, one under B).
+	assert.Equal(t, 2, strings.Count(output, "Security issues:"))
+	// A single result => no aggregate summary, exactly one shared Test Summary box.
+	assert.NotContains(t, output, "Overall Test Summary")
+	assert.Equal(t, 1, strings.Count(output, "Test Summary"))
+	snaps.MatchSnapshot(t, output)
+}
+
+func TestUnifiedFindingPresenter_SingleComponent_NoComponentHeader(t *testing.T) {
+	config := configuration.New()
+	buffer := &bytes.Buffer{}
+	lipgloss.SetColorProfile(termenv.Ascii)
+
+	finding := testapi.FindingData{
+		Id:   util.Ptr(uuid.New()),
+		Type: util.Ptr(testapi.Findings),
+		Attributes: &testapi.FindingAttributes{
+			Title:        "single component issue",
+			Rating:       testapi.Rating{Severity: testapi.SeverityHigh},
+			ComponentKey: util.Ptr("pkg:npm/only@1.0.0"),
+		},
+	}
+
+	results := []*presenters.UnifiedProjectResult{
+		{
+			Findings:          []testapi.FindingData{finding},
+			TargetDirectory:   "my-sbom.json",
+			DisplayTargetFile: "",
+			Summary: &json_schemas.TestSummary{
+				Type:             "open-source",
+				SeverityOrderAsc: []string{"low", "medium", "high", "critical"},
+			},
+		},
+	}
+
+	presenter := presenters.NewUnifiedFindingsRenderer(results, config, buffer)
+	err := presenter.RenderTemplate(presenters.DefaultTemplateFiles, presenters.DefaultMimeType)
+	require.NoError(t, err)
+
+	// With fewer than two distinct components, findings render as a flat list with no component header.
+	assert.NotContains(t, buffer.String(), "Component:")
+}
+
 func TestUnifiedFindingPresenter_SingleProject_NoAggregateSummary(t *testing.T) {
 	config := configuration.New()
 	buffer := &bytes.Buffer{}

--- a/internal/presenters/templates/unified_finding.tmpl
+++ b/internal/presenters/templates/unified_finding.tmpl
@@ -39,17 +39,13 @@
 
 {{end}}
 
-{{- define "details" -}}
-    {{- $sortedFindings := .Findings | sortFindingBy "Attributes.Rating.Severity" .Summary.SeverityOrderAsc }}
+{{- define "findingSections" -}}
+    {{- $sortedFindings := .Findings | sortFindingBy "Attributes.Rating.Severity" .SeverityOrder }}
     {{- $allOpenFindings := $sortedFindings | filterFinding (isOpenFinding) }}
     {{- $openFindings := $allOpenFindings | filterFinding (isNotLicenseFindingFilter) }}
     {{- $licenseFindings := $allOpenFindings | filterFinding (isLicenseFindingFilter) }}
-    {{- $pendingIgnoreFindings := $sortedFindings | filterFinding (isPendingFinding) }}
-    {{- $ignoredFindings := $sortedFindings | filterFinding (isIgnoredFinding) }}
     {{- $hasOpenFindings := gt (len $openFindings) 0 }}
     {{- $hasLicenseFindings := gt (len $licenseFindings) 0 }}
-    {{- $hasPendingIgnoreFindings := gt (len $pendingIgnoreFindings) 0 }}
-    {{- $hasIgnoredFindings := gt (len $ignoredFindings) 0 }}
 
     {{- if $hasOpenFindings }}{{ printf "Security issues: %d" (len $openFindings) | title }}
 		{{- range $finding := $openFindings }}
@@ -78,6 +74,22 @@
 			{{- template "finding_details" $finding -}}
 		{{- end }}
     {{- end }}
+{{- end }}{{/* end "findingSections" */}}
+
+{{- define "details" -}}
+    {{- $summary := .Summary -}}
+    {{- range $group := groupFindingsByComponent .Findings }}
+        {{- if $group.Component }}
+{{ printf "Component: %s" $group.Component | bold }}
+        {{- end }}
+        {{- template "findingSections" (summaryData $group.Findings $summary.SeverityOrderAsc) }}
+    {{- end }}
+
+    {{- $sortedFindings := .Findings | sortFindingBy "Attributes.Rating.Severity" .Summary.SeverityOrderAsc }}
+    {{- $openFindings := $sortedFindings | filterFinding (isOpenFinding) | filterFinding (isNotLicenseFindingFilter) }}
+    {{- $ignoredFindings := $sortedFindings | filterFinding (isIgnoredFinding) }}
+    {{- $hasOpenFindings := gt (len $openFindings) 0 }}
+    {{- $hasIgnoredFindings := gt (len $ignoredFindings) 0 }}
     {{- if or (and $hasOpenFindings $hasIgnoredFindings) (eq (getValueFromConfig "include-ignores") "true") }}
 		{{- divider }}
     {{- end}}


### PR DESCRIPTION
`snyk sbom test`, `sbom test --report`, and the dragonfly flavour of `snyk test --all-projects` previously rendered all findings as one flat list with no indication of which SBOM component each finding belonged to. This groups the human-readable output under `Component: <key>` sub-headers (keyed on `FindingData.Attributes.ComponentKey`), keeping a single shared `Test Summary`.

All three commands funnel through the same `runTestInternal` → `prepareOutput` path, so the change is localized there. Findings for the human-readable payload are now consolidated *per component* — the existing global consolidation collapses a vuln shared across components into one finding, which would hide it from every component but one. Global consolidation is retained for the exit-code summary and legacy JSON, so those (and `--json` output) are unchanged; scope here is human-readable output only. When fewer than two distinct components are present (regular `snyk test`, single-component SBOMs), output is byte-identical to before — existing snapshots are untouched.

Note: `component_key` was previously unconsumed in this repo; the grouping depends on the test-api populating it for SBOM tests and degrades gracefully to the flat list if it is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)