### PR TITLE
feat: set TestConfiguration.monitor from --monitor flag [OSF-449]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/snyk/cli-extension-dep-graph/v2 v2.6.0
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90
-	github.com/snyk/go-application-framework v0.6.1
+	github.com/snyk/go-application-framework v0.7.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/net v0.55.0
@@ -117,6 +117,7 @@ require (
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/term v0.44.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90 h1:MumWzLKiIFhZEk/wP71S/zv2cceygDb3+KNXGBb1hC0=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.6.1 h1:cTTgoN5n0kG55SEAvTmaN79Rn0Q9PXYr2tSToyvvWkA=
-github.com/snyk/go-application-framework v0.6.1/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
+github.com/snyk/go-application-framework v0.7.2 h1:WzZ7BeFL0pKoB2YdheHtEgEdeB+9nunmwQP8XI+rKcc=
+github.com/snyk/go-application-framework v0.7.2/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530 h1:s9PHNkL6ueYRiAKNfd8OVxlUOqU3qY0VDbgCD1f6WQY=
 github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/internal/commands/osmonitor/dfly_depgraph_flow.go
+++ b/internal/commands/osmonitor/dfly_depgraph_flow.go
@@ -10,12 +10,12 @@ import (
 	"github.com/snyk/cli-extension-os-flows/internal/commands/cmdctx"
 	"github.com/snyk/cli-extension-os-flows/internal/commands/ostest"
 	"github.com/snyk/cli-extension-os-flows/internal/common"
-	"github.com/snyk/cli-extension-os-flows/internal/util"
+	"github.com/snyk/cli-extension-os-flows/pkg/flags"
 )
 
 // RunDflyMonitorFlow runs the dragonfly depgraph flow for `snyk monitor`.
 // It iterates over all input directories, resolves dep graphs, uploads them,
-// runs a test with publish_report=true, and returns the aggregated workflow output.
+// runs a test with monitor=true, and returns the aggregated workflow output.
 func RunDflyMonitorFlow(
 	ctx context.Context,
 	inputDirs []string,
@@ -23,6 +23,7 @@ func RunDflyMonitorFlow(
 	clients common.FlowClients,
 ) ([]workflow.Data, error) {
 	cfg := cmdctx.Config(ctx)
+	cfg.Set(flags.FlagMonitor, true)
 	dgResolver := common.NewDepgraphResolver()
 	var allWfData []workflow.Data
 
@@ -38,7 +39,7 @@ func RunDflyMonitorFlow(
 		}
 
 		_, wfData, err := common.RunDflyDepgraphFlow(
-			ctx, inputDir, dgResolver, clients, orgUUID, localPolicy, reachOpts, util.Ptr(true), ostest.RunTestWithResources,
+			ctx, inputDir, dgResolver, clients, orgUUID, localPolicy, reachOpts, ostest.RunTestWithResources,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run depgraph flow: %w", err)

--- a/internal/commands/osmonitor/dfly_depgraph_flow_test.go
+++ b/internal/commands/osmonitor/dfly_depgraph_flow_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/snyk/cli-extension-os-flows/internal/commands/ostest"
 	"github.com/snyk/cli-extension-os-flows/internal/common"
 	"github.com/snyk/cli-extension-os-flows/internal/constants"
-	"github.com/snyk/cli-extension-os-flows/internal/util"
 	"github.com/snyk/cli-extension-os-flows/pkg/flags"
 )
 
@@ -23,7 +22,8 @@ func Test_RunDflyMonitorFlow_JSON(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	ctx, orgID, _ := setupDflyTestFixture(t, ctrl)
+	ctx, orgID, cfg := setupDflyTestFixture(t, ctrl)
+	cfg.Set(flags.FlagMonitor, true)
 	mockTestClient := setupMockTestClient(t, ctrl)
 	ffc := fileupload.NewFakeClient()
 	fdr := newSinglePkgDepgraphResolver()
@@ -31,7 +31,7 @@ func Test_RunDflyMonitorFlow_JSON(t *testing.T) {
 	_, wfData, err := common.RunDflyDepgraphFlow(
 		ctx, ".", fdr,
 		common.FlowClients{FileUploadClient: ffc, TestClient: mockTestClient},
-		orgID, nil, nil, util.Ptr(true),
+		orgID, nil, nil,
 		ostest.RunTestWithResources,
 	)
 	require.NoError(t, err)
@@ -40,11 +40,12 @@ func Test_RunDflyMonitorFlow_JSON(t *testing.T) {
 	require.NotEmpty(t, wfData)
 }
 
-func Test_RunDflyMonitorFlow_PublishReportIsSet(t *testing.T) {
+func Test_RunDflyMonitorFlow_MonitorIsSet(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	ctx, orgID, _ := setupDflyTestFixture(t, ctrl)
+	ctx, orgID, cfg := setupDflyTestFixture(t, ctrl)
+	cfg.Set(flags.FlagMonitor, true)
 	mockTestClient, getCapturedConfig := setupCapturingTestClient(ctrl)
 	ffc := fileupload.NewFakeClient()
 	fdr := newSinglePkgDepgraphResolver()
@@ -52,15 +53,16 @@ func Test_RunDflyMonitorFlow_PublishReportIsSet(t *testing.T) {
 	_, _, err := common.RunDflyDepgraphFlow(
 		ctx, ".", fdr,
 		common.FlowClients{FileUploadClient: ffc, TestClient: mockTestClient},
-		orgID, nil, nil, util.Ptr(true),
+		orgID, nil, nil,
 		ostest.RunTestWithResources,
 	)
 	require.NoError(t, err)
 
 	capturedConfig := getCapturedConfig()
 	require.NotNil(t, capturedConfig)
-	require.NotNil(t, capturedConfig.PublishReport)
-	assert.True(t, *capturedConfig.PublishReport)
+	require.NotNil(t, capturedConfig.Monitor)
+	assert.True(t, *capturedConfig.Monitor)
+	assert.Nil(t, capturedConfig.PublishReport, "the monitor command sets --monitor, not --report")
 }
 
 func Test_RunDflyMonitorFlow_ProjectMetadataForwarded(t *testing.T) {
@@ -68,6 +70,7 @@ func Test_RunDflyMonitorFlow_ProjectMetadataForwarded(t *testing.T) {
 	defer ctrl.Finish()
 
 	ctx, orgID, cfg := setupDflyTestFixture(t, ctrl)
+	cfg.Set(flags.FlagMonitor, true)
 	cfg.Set(flags.FlagTargetReference, "main")
 	cfg.Set(flags.FlagAssetName, "my-target")
 	cfg.Set(flags.FlagProjectBusinessCriticality, "high")
@@ -82,7 +85,7 @@ func Test_RunDflyMonitorFlow_ProjectMetadataForwarded(t *testing.T) {
 	_, _, err := common.RunDflyDepgraphFlow(
 		ctx, ".", fdr,
 		common.FlowClients{FileUploadClient: ffc, TestClient: mockTestClient},
-		orgID, nil, nil, util.Ptr(true),
+		orgID, nil, nil,
 		ostest.RunTestWithResources,
 	)
 	require.NoError(t, err)
@@ -107,7 +110,8 @@ func Test_RunDflyMonitorFlow_UploadFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	ctx, orgID, _ := setupDflyTestFixture(t, ctrl)
+	ctx, orgID, cfg := setupDflyTestFixture(t, ctrl)
+	cfg.Set(flags.FlagMonitor, true)
 	mockTestClient := gafclientmocks.NewMockTestClient(ctrl)
 	ffc := fileupload.NewFakeClient()
 	ffc.WithError(assert.AnError)
@@ -116,7 +120,7 @@ func Test_RunDflyMonitorFlow_UploadFailure(t *testing.T) {
 	_, _, err := common.RunDflyDepgraphFlow(
 		ctx, ".", fdr,
 		common.FlowClients{FileUploadClient: ffc, TestClient: mockTestClient},
-		orgID, nil, nil, util.Ptr(true),
+		orgID, nil, nil,
 		ostest.RunTestWithResources,
 	)
 	assert.ErrorContains(t, err, "failed to upload dependency graphs")

--- a/internal/commands/ostest/sbom_flow_test.go
+++ b/internal/commands/ostest/sbom_flow_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snyk/cli-extension-os-flows/internal/outputworkflow"
 	"github.com/snyk/cli-extension-os-flows/internal/presenters"
 	"github.com/snyk/cli-extension-os-flows/internal/util"
+	"github.com/snyk/cli-extension-os-flows/pkg/flags"
 )
 
 // idRgxp is used for replacing the "id" in the output for snapshot consistency.
@@ -60,8 +61,7 @@ func Test_RunSbomFlow_Reachability_JSON(t *testing.T) {
 		common.FlowClients{TestClient: mockTestClient, FileUploadClient: ffc, DeeproxyClient: fdc},
 		orgID,
 		nil,
-		&common.ReachabilityOpts{SourceDir: sourceCodePath},
-		nil, ostest.RunTestWithResources,
+		&common.ReachabilityOpts{SourceDir: sourceCodePath}, ostest.RunTestWithResources,
 	)
 	require.NoError(t, err)
 
@@ -106,8 +106,7 @@ func Test_RunSbomFlow_Reachability_HumanReadable(t *testing.T) {
 		common.FlowClients{TestClient: mockTestClient, FileUploadClient: ffc, DeeproxyClient: fdc},
 		orgID,
 		nil,
-		&common.ReachabilityOpts{SourceDir: sourceCodePath},
-		nil, ostest.RunTestWithResources,
+		&common.ReachabilityOpts{SourceDir: sourceCodePath}, ostest.RunTestWithResources,
 	)
 	require.NoError(t, err)
 
@@ -158,7 +157,6 @@ func Test_RunSbomFlow_NoReachability_JSON(t *testing.T) {
 		common.FlowClients{TestClient: mockTestClient, FileUploadClient: ffc, DeeproxyClient: fdc},
 		orgID,
 		nil,
-		nil,
 		nil, ostest.RunTestWithResources,
 	)
 	require.NoError(t, err)
@@ -204,7 +202,6 @@ func Test_RunSbomFlow_NoReachability_HumanReadable(t *testing.T) {
 		common.FlowClients{TestClient: mockTestClient, FileUploadClient: ffc, DeeproxyClient: fdc},
 		orgID,
 		nil,
-		nil,
 		nil, ostest.RunTestWithResources,
 	)
 	require.NoError(t, err)
@@ -244,6 +241,7 @@ func Test_RunSbomFlow_HumanReadable_PropagatesAssetLink(t *testing.T) {
 
 	ef := errors.NewErrorFactory(&nopLogger)
 	mockIctx, mockTestClient, ffc, fdc, orgID, sbomPath, _ := setupTestWithAssetLink(t, ctrl, false, assetURL)
+	mockIctx.GetConfiguration().Set(flags.FlagReport, true)
 	ctx := t.Context()
 	ctx = cmdctx.WithIctx(ctx, mockIctx)
 	ctx = cmdctx.WithConfig(ctx, mockIctx.GetConfiguration())
@@ -258,7 +256,7 @@ func Test_RunSbomFlow_HumanReadable_PropagatesAssetLink(t *testing.T) {
 		orgID,
 		nil,
 		nil,
-		util.Ptr(true), ostest.RunTestWithResources,
+		ostest.RunTestWithResources,
 	)
 	require.NoError(t, err)
 	require.NotNil(t, outputData)
@@ -296,8 +294,7 @@ func Test_RunSbomFlow_SkipsSourceUploadWhenNoSupportedSources(t *testing.T) {
 		common.FlowClients{TestClient: mockTestClient, FileUploadClient: ffc, DeeproxyClient: fdc},
 		orgID,
 		nil,
-		&common.ReachabilityOpts{SourceDir: sourceDir},
-		nil, ostest.RunTestWithResources,
+		&common.ReachabilityOpts{SourceDir: sourceDir}, ostest.RunTestWithResources,
 	)
 	require.NoError(t, err)
 

--- a/internal/commands/ostest/workflow.go
+++ b/internal/commands/ostest/workflow.go
@@ -33,7 +33,6 @@ import (
 	"github.com/snyk/cli-extension-os-flows/internal/legacy/validation"
 	"github.com/snyk/cli-extension-os-flows/internal/outputworkflow"
 	"github.com/snyk/cli-extension-os-flows/internal/presenters"
-	"github.com/snyk/cli-extension-os-flows/internal/util"
 	"github.com/snyk/cli-extension-os-flows/pkg/flags"
 )
 
@@ -125,30 +124,21 @@ func executeFlow(
 	localPolicy *testapi.LocalPolicy,
 	reachability bool,
 ) ([]definitions.LegacyVulnerabilityResponse, []workflow.Data, error) {
-	cfg := cmdctx.Config(ctx)
-
 	var reachOpts *common.ReachabilityOpts
 	if reachability {
 		reachOpts = &common.ReachabilityOpts{SourceDir: sourceDir}
 	}
 
-	// `--report` instructs the test API to persist the result as a monitored
-	// project. This is the supported successor to the removed `sbom monitor`.
-	var publishReport *bool
-	if cfg.GetBool(flags.FlagReport) {
-		publishReport = util.Ptr(true)
-	}
-
 	switch flow {
 	case SbomFlow:
-		findings, data, err := common.RunSbomFlow(ctx, sbom, clients, orgUUID, localPolicy, reachOpts, publishReport, RunTestWithResources)
+		findings, data, err := common.RunSbomFlow(ctx, sbom, clients, orgUUID, localPolicy, reachOpts, RunTestWithResources)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to run sbom flow: %w", err)
 		}
 		return findings, data, nil
 	case DflyDepgraphFlow:
 		dgResolver := common.NewDepgraphResolver()
-		findings, data, err := common.RunDflyDepgraphFlow(ctx, inputDir, dgResolver, clients, orgUUID, localPolicy, reachOpts, nil, RunTestWithResources)
+		findings, data, err := common.RunDflyDepgraphFlow(ctx, inputDir, dgResolver, clients, orgUUID, localPolicy, reachOpts, RunTestWithResources)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to run depgraph flow: %w", err)
 		}

--- a/internal/common/dfly_depgraph_flow.go
+++ b/internal/common/dfly_depgraph_flow.go
@@ -48,8 +48,6 @@ func createDepgraphTmpFiles(depGraphs []DepgraphWithIdentity) (rootTmpDir string
 }
 
 // RunDflyDepgraphFlow handles the depGraph flow, fully through dragonfly.
-// publishReport controls whether the test result is persisted as a monitored project;
-// pass util.Ptr(true) for monitor, nil for test.
 // runTest is the function used to execute the actual test against the test API.
 func RunDflyDepgraphFlow(
 	ctx context.Context,
@@ -59,7 +57,6 @@ func RunDflyDepgraphFlow(
 	orgUUID uuid.UUID,
 	localPolicy *testapi.LocalPolicy,
 	reachabilityOpts *ReachabilityOpts,
-	publishReport *bool,
 	runTest RunTestWithResourcesFunc,
 ) ([]definitions.LegacyVulnerabilityResponse, []workflow.Data, error) {
 	ictx := cmdctx.Ictx(ctx)
@@ -126,7 +123,7 @@ func RunDflyDepgraphFlow(
 		}
 	}
 
-	testConfig := BuildTestConfig(cfg, localPolicy, publishReport)
+	testConfig := BuildTestConfig(cfg, localPolicy)
 
 	projectName := depGraphs[0].Identity.Name
 	targetFile := depGraphs[0].Identity.TargetFile
@@ -148,14 +145,13 @@ func RunDflyDepgraphFlow(
 	return legacyVulnRes, wfData, err
 }
 
-// BuildTestConfig creates a TestConfiguration from CLI flags, a local policy, and an optional publish report flag.
-func BuildTestConfig(cfg configuration.Configuration, localPolicy *testapi.LocalPolicy, publishReport *bool) *testapi.TestConfiguration {
+// BuildTestConfig creates a TestConfiguration from CLI flags and a local policy.
+func BuildTestConfig(cfg configuration.Configuration, localPolicy *testapi.LocalPolicy) *testapi.TestConfiguration {
 	testConfig := &testapi.TestConfiguration{
 		LocalPolicy: localPolicy,
 		ScanConfig: &testapi.ScanConfiguration{
 			Sca: &testapi.ScaScanConfiguration{},
 		},
-		PublishReport: publishReport,
 	}
 	if tr := cfg.GetString(flags.FlagTargetReference); tr != "" {
 		testConfig.TargetReference = &tr
@@ -163,8 +159,9 @@ func BuildTestConfig(cfg configuration.Configuration, localPolicy *testapi.Local
 	if tn := cfg.GetString(flags.FlagAssetName); tn != "" {
 		testConfig.AssetName = &tn
 	}
-	// --monitor persists the result as a monitored project with recurring retests.
-	// Independent of --report (PublishReport); other callers never set this key.
+	if cfg.GetBool(flags.FlagReport) {
+		testConfig.PublishReport = util.Ptr(true)
+	}
 	if cfg.GetBool(flags.FlagMonitor) {
 		testConfig.Monitor = util.Ptr(true)
 	}

--- a/internal/common/dfly_depgraph_flow.go
+++ b/internal/common/dfly_depgraph_flow.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/snyk/cli-extension-os-flows/internal/commands/cmdctx"
 	"github.com/snyk/cli-extension-os-flows/internal/legacy/definitions"
+	"github.com/snyk/cli-extension-os-flows/internal/util"
 	"github.com/snyk/cli-extension-os-flows/pkg/flags"
 )
 
@@ -161,6 +162,11 @@ func BuildTestConfig(cfg configuration.Configuration, localPolicy *testapi.Local
 	}
 	if tn := cfg.GetString(flags.FlagAssetName); tn != "" {
 		testConfig.AssetName = &tn
+	}
+	// --monitor persists the result as a monitored project with recurring retests.
+	// Independent of --report (PublishReport); other callers never set this key.
+	if cfg.GetBool(flags.FlagMonitor) {
+		testConfig.Monitor = util.Ptr(true)
 	}
 	if pbc := cfg.GetString(flags.FlagProjectBusinessCriticality); pbc != "" {
 		testConfig.ProjectBusinessCriticality = &pbc

--- a/internal/common/dfly_depgraph_flow_test.go
+++ b/internal/common/dfly_depgraph_flow_test.go
@@ -79,7 +79,6 @@ func Test_RunDflyDepgraphFlow_JSON(t *testing.T) {
 		orgID,
 		nil,
 		nil,
-		nil,
 		ostest.RunTestWithResources,
 	)
 	require.NoError(t, err)
@@ -144,7 +143,6 @@ func Test_RunDflyDepgraphFlow_HumanReadable(t *testing.T) {
 		fdr,
 		common.FlowClients{FileUploadClient: ffc, TestClient: mockTestClient},
 		orgID,
-		nil,
 		nil,
 		nil,
 		ostest.RunTestWithResources,
@@ -215,7 +213,7 @@ func Test_RunDflyDepgraphFlow_UploadingDepgraphsFail(t *testing.T) {
 	_, _, err := common.RunDflyDepgraphFlow(
 		ctx, ".", fdr,
 		common.FlowClients{FileUploadClient: ffc, TestClient: mockTestClient},
-		orgID, nil, nil, nil, ostest.RunTestWithResources,
+		orgID, nil, nil, ostest.RunTestWithResources,
 	)
 	assert.ErrorContains(t, err, "failed to upload dependency graphs")
 }
@@ -239,7 +237,7 @@ func Test_RunDflyDepgraphFlow_DepgraphResolverFails(t *testing.T) {
 	_, _, err := common.RunDflyDepgraphFlow(
 		ctx, ".", fdr,
 		common.FlowClients{FileUploadClient: ffc, TestClient: mockTestClient},
-		orgID, nil, nil, nil, ostest.RunTestWithResources,
+		orgID, nil, nil, ostest.RunTestWithResources,
 	)
 	assert.ErrorContains(t, err, "failed to extract dependency graphs")
 }
@@ -279,7 +277,7 @@ func Test_RunDflyDepgraphFlow_SkipsSourceUploadWhenNoSupportedSources(t *testing
 	_, _, err := common.RunDflyDepgraphFlow(
 		ctx, ".", fdr,
 		common.FlowClients{FileUploadClient: ffc, TestClient: mockTestClient},
-		orgID, nil, &common.ReachabilityOpts{SourceDir: sourceDir}, nil,
+		orgID, nil, &common.ReachabilityOpts{SourceDir: sourceDir},
 		ostest.RunTestWithResources,
 	)
 	require.NoError(t, err)
@@ -340,7 +338,7 @@ func Test_RunDflyDepgraphFlow_ConfigMetadataForwarded(t *testing.T) {
 	_, _, err := common.RunDflyDepgraphFlow(
 		ctx, ".", fdr,
 		common.FlowClients{FileUploadClient: ffc, TestClient: mockTestClient},
-		orgID, nil, nil, nil,
+		orgID, nil, nil,
 		ostest.RunTestWithResources,
 	)
 	require.NoError(t, err)
@@ -397,16 +395,19 @@ func Test_RunDflyDepgraphFlow_PublishReportForwarded(t *testing.T) {
 		},
 	}, nil)
 
+	cfg := mockIctx.GetConfiguration()
+	cfg.Set(flags.FlagReport, true)
+
 	ctx := t.Context()
 	ctx = cmdctx.WithIctx(ctx, mockIctx)
 	ctx = cmdctx.WithLogger(ctx, &dflyNopLogger)
 	ctx = cmdctx.WithProgressBar(ctx, &dflyNopProgressBar)
-	ctx = cmdctx.WithConfig(ctx, mockIctx.GetConfiguration())
+	ctx = cmdctx.WithConfig(ctx, cfg)
 
 	_, _, err := common.RunDflyDepgraphFlow(
 		ctx, ".", fdr,
 		common.FlowClients{FileUploadClient: ffc, TestClient: mockTestClient},
-		orgID, nil, nil, util.Ptr(true),
+		orgID, nil, nil,
 		ostest.RunTestWithResources,
 	)
 	require.NoError(t, err)
@@ -463,7 +464,7 @@ func Test_RunDflyDepgraphFlow_TagsFallbackToProjectTags(t *testing.T) {
 	_, _, err := common.RunDflyDepgraphFlow(
 		ctx, ".", fdr,
 		common.FlowClients{FileUploadClient: ffc, TestClient: mockTestClient},
-		orgID, nil, nil, nil,
+		orgID, nil, nil,
 		ostest.RunTestWithResources,
 	)
 	require.NoError(t, err)
@@ -765,15 +766,32 @@ func Test_BuildTestConfig_MonitorFlagSetsMonitor(t *testing.T) {
 	cfg := configuration.New()
 	cfg.Set(flags.FlagMonitor, true)
 
-	tc := common.BuildTestConfig(cfg, nil, nil) // publishReport nil => report unaffected
+	tc := common.BuildTestConfig(cfg, nil)
 
 	require.NotNil(t, tc.Monitor)
 	assert.True(t, *tc.Monitor)
-	assert.Nil(t, tc.PublishReport, "--monitor must not imply --report (DD1)")
+	assert.Nil(t, tc.PublishReport, "--monitor must not imply --report")
 }
 
 func Test_BuildTestConfig_NoMonitorFlagLeavesMonitorNil(t *testing.T) {
 	cfg := configuration.New()
-	tc := common.BuildTestConfig(cfg, nil, nil)
+	tc := common.BuildTestConfig(cfg, nil)
 	assert.Nil(t, tc.Monitor)
+}
+
+func Test_BuildTestConfig_ReportFlagSetsPublishReport(t *testing.T) {
+	cfg := configuration.New()
+	cfg.Set(flags.FlagReport, true)
+
+	tc := common.BuildTestConfig(cfg, nil)
+
+	require.NotNil(t, tc.PublishReport)
+	assert.True(t, *tc.PublishReport)
+	assert.Nil(t, tc.Monitor, "--report must not imply --monitor")
+}
+
+func Test_BuildTestConfig_NoReportFlagLeavesPublishReportNil(t *testing.T) {
+	cfg := configuration.New()
+	tc := common.BuildTestConfig(cfg, nil)
+	assert.Nil(t, tc.PublishReport)
 }

--- a/internal/common/dfly_depgraph_flow_test.go
+++ b/internal/common/dfly_depgraph_flow_test.go
@@ -760,3 +760,20 @@ func dflyAFinding(t *testing.T) testapi.FindingData {
 		},
 	}
 }
+
+func Test_BuildTestConfig_MonitorFlagSetsMonitor(t *testing.T) {
+	cfg := configuration.New()
+	cfg.Set(flags.FlagMonitor, true)
+
+	tc := common.BuildTestConfig(cfg, nil, nil) // publishReport nil => report unaffected
+
+	require.NotNil(t, tc.Monitor)
+	assert.True(t, *tc.Monitor)
+	assert.Nil(t, tc.PublishReport, "--monitor must not imply --report (DD1)")
+}
+
+func Test_BuildTestConfig_NoMonitorFlagLeavesMonitorNil(t *testing.T) {
+	cfg := configuration.New()
+	tc := common.BuildTestConfig(cfg, nil, nil)
+	assert.Nil(t, tc.Monitor)
+}

--- a/internal/common/sbom_flow.go
+++ b/internal/common/sbom_flow.go
@@ -17,8 +17,6 @@ import (
 
 // RunSbomFlow uploads an SBOM document, resolves SCM context, optionally uploads
 // source code for reachability, and runs a test via the test API.
-// publishReport controls whether the test result is persisted as a monitored project;
-// pass util.Ptr(true) for monitor, nil for test.
 // runTest is the function used to execute the actual test against the test API.
 func RunSbomFlow(
 	ctx context.Context,
@@ -27,7 +25,6 @@ func RunSbomFlow(
 	orgUUID uuid.UUID,
 	localPolicy *testapi.LocalPolicy,
 	reachabilityOpts *ReachabilityOpts,
-	publishReport *bool,
 	runTest RunTestWithResourcesFunc,
 ) ([]definitions.LegacyVulnerabilityResponse, []workflow.Data, error) {
 	cfg := cmdctx.Config(ctx)
@@ -71,7 +68,7 @@ func RunSbomFlow(
 		}
 	}
 
-	testConfig := BuildTestConfig(cfg, localPolicy, publishReport)
+	testConfig := BuildTestConfig(cfg, localPolicy)
 
 	osAnalysisStart := time.Now()
 	legacyVuln, wfData, err := runTest(

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -85,6 +85,10 @@ const (
 	// (`snyk sbom test --report --file=<sbom>`) to replace `snyk sbom monitor`.
 	FlagReport = "report"
 
+	// FlagMonitor persists the test result as a monitored project with recurring
+	// (daily) retests. Independent of --report; sets TestConfiguration.monitor.
+	FlagMonitor = "monitor"
+
 	// Output file flags (used by test and validation).
 	FlagJSONFileOutput  = "json-file-output"
 	FlagSarifFileOutput = "sarif-file-output"
@@ -116,6 +120,7 @@ func OSTestFlagSet() *pflag.FlagSet {
 	// --report (and accompanying project-attribute flags) persists the test as a monitored
 	// project. This is the supported replacement for the removed `snyk sbom monitor` command.
 	flagSet.Bool(FlagReport, false, "Share results with the Snyk Web UI, persisting them as a monitored project.")
+	flagSet.Bool(FlagMonitor, false, "Monitor this project with recurring tests (daily retest frequency).")
 	flagSet.String(FlagProjectEnvironment, "", "Set the project environment project attribute to one or more values (comma-separated).")
 	if f := flagSet.Lookup(FlagProjectEnvironment); f != nil {
 		f.NoOptDefVal = InvalidFlagValue

--- a/pkg/flags/flags_test.go
+++ b/pkg/flags/flags_test.go
@@ -99,6 +99,13 @@ func TestHTMLFlags(t *testing.T) {
 	})
 }
 
+func TestOSTestFlagSet_HasMonitorFlag(t *testing.T) {
+	fs := flags.OSTestFlagSet()
+	f := fs.Lookup(flags.FlagMonitor)
+	require.NotNil(t, f, "expected --monitor to be registered on the OS test flag set")
+	assert.Equal(t, "false", f.DefValue, "--monitor should default to false")
+}
+
 func TestRemoteRepoURLFlag(t *testing.T) {
 	flagSets := []struct {
 		name     string


### PR DESCRIPTION
Adds support for the `--monitor` signal on the OS test workflow so that `snyk sbom test --monitor` can persist a test result as a monitored project with a **daily** retest frequency, as opposed to `--report` which persists with a **never** frequency.

This is the os-flows half of OSF-449; the `--monitor` flag surface lives in `cli-extension-sbom` (companion PR) and reaches this workflow by string config key via `engine.InvokeWithConfig`. Changes here: bump go-application-framework to v0.7.2 (first version carrying `TestConfiguration.Monitor`), register `--monitor` on the OS test flag set, and set `TestConfiguration.Monitor` in `BuildTestConfig` when the key is present. Per the ticket owner (DD1), `--report` and `--monitor` are independent booleans — `--monitor` does not imply `--report`. Other callers of `BuildTestConfig` never set the key, so `Monitor` stays nil for them.

Ticket: https://snyksec.atlassian.net/browse/OSF-449