### PR TITLE
build: bump Go toolchain to 1.26.4 to patch stdlib vulnerabilities

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   unit-test:
     executor:
       name: go/default
-      tag: "1.26.3"
+      tag: "1.26.4"
     steps:
       - checkout
       - go/load-cache
@@ -23,7 +23,7 @@ jobs:
   integration-test:
     executor:
       name: go/default
-      tag: "1.26.3"
+      tag: "1.26.4"
     steps:
       - checkout
       - go/load-cache
@@ -43,7 +43,7 @@ jobs:
   security-scans:
     executor:
       name: go/default
-      tag: "1.26.3"
+      tag: "1.26.4"
     resource_class: small
     steps:
       - checkout

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 nodejs 20.19.5
-golang 1.26.3
+golang 1.26.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/cli-extension-os-flows
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.0


### PR DESCRIPTION
Bumps the Go toolchain from 1.26.3 to 1.26.4 to remediate two HIGH-severity Snyk gate blockers.

Both issues — `SNYK-GOLANG-STDCRYPTOX509-17135840` (std/crypto/x509) and `SNYK-GOLANG-STDMIME-17135844` (std/mime) — are in the Go standard library, so they are pinned to the toolchain version rather than any third-party dependency. Both are fixed in 1.26.4. The version pin is updated consistently across `go.mod`, `.tool-versions`, and the three CircleCI executors in `.circleci/config.yml`; no module dependencies changed, so `go.sum` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)