### PR TITLE
Report one result per component for SBOM tests [OSF-294]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/snyk/cli-extension-dep-graph/v2 v2.6.0
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6
-	github.com/snyk/go-application-framework v0.14.2
+	github.com/snyk/go-application-framework v0.16.1
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/net v0.57.0

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.14.2 h1:NrhI93DOwpWpsVErgh28akeXR/Yf/J9ZmqmQLRRSXXM=
-github.com/snyk/go-application-framework v0.14.2/go.mod h1:qJBU+FIY8s/lIg0IaKBj7WGeGERiWqyJvhajzxiA3Ls=
+github.com/snyk/go-application-framework v0.16.1 h1:k4eyP4EX/kqnNyu5uuFLEw4wflTom22ea23ZuG74JU8=
+github.com/snyk/go-application-framework v0.16.1/go.mod h1:qJBU+FIY8s/lIg0IaKBj7WGeGERiWqyJvhajzxiA3Ls=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/internal/commands/ostest/component_test_result.go
+++ b/internal/commands/ostest/component_test_result.go
@@ -8,8 +8,11 @@ import (
 )
 
 // Metadata keys that describe the test run as a whole rather than any one component. They
-// are rendered once, on the last component, so that splitting a test's results does not
-// repeat the same link under every component.
+// are reported once, on the last component, so that splitting a test's results does not
+// report the same link under every component.
+//
+// This is about the reported metadata only. Where the CLI prints the asset link is decided
+// by the presenter, which renders it once below the overall test summary.
 var testWideMetadataKeys = []string{"asset", "report-url"}
 
 // componentTestResult presents a single component of a test as a test result in its own right.
@@ -113,7 +116,7 @@ func componentTestResults(
 			metadata = map[string]interface{}{}
 		}
 
-		// Only the last component keeps the test-wide links, so they render once.
+		// Only the last component keeps the test-wide links, so they are reported once.
 		if i < len(split)-1 {
 			for _, key := range testWideMetadataKeys {
 				delete(metadata, key)

--- a/internal/commands/ostest/component_test_result.go
+++ b/internal/commands/ostest/component_test_result.go
@@ -7,22 +7,6 @@ import (
 	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
 )
 
-// Metadata keys that describe the test run as a whole rather than any one component. They
-// are reported once, on the last component, so that splitting a test's results does not
-// report the same link under every component.
-//
-// This is about the reported metadata only. Where the CLI prints the asset link is decided
-// by the presenter, which renders it once below the overall test summary.
-var testWideMetadataKeys = []string{"asset", "report-url"}
-
-// componentTestResult presents a single component of a test as a test result in its own right.
-//
-// The test API reports an SBOM test as one test covering many components, but the unified
-// findings presenter renders one section per test result. Wrapping each component as its own
-// result gives SBOM tests the same per-project output as `snyk test --all-projects`, where
-// every project genuinely is a separate test.
-//
-// Everything not scoped to a component is delegated to the underlying test result.
 type componentTestResult struct {
 	testapi.TestResult
 
@@ -33,7 +17,6 @@ type componentTestResult struct {
 	raw        *testapi.FindingSummary
 }
 
-// newComponentTestResult wraps result as the test result for a single component.
 func newComponentTestResult(
 	result testapi.TestResult,
 	component ComponentFindings,
@@ -98,9 +81,6 @@ func (c *componentTestResult) GetRawSummary() *testapi.FindingSummary {
 	return c.raw
 }
 
-// componentTestResults wraps each component as its own test result. Component metadata is
-// derived from the base metadata so that anything the flow set on the test as a whole, such
-// as the package manager, is carried over.
 func componentTestResults(
 	result testapi.TestResult,
 	split []ComponentFindings,
@@ -116,13 +96,6 @@ func componentTestResults(
 			metadata = map[string]interface{}{}
 		}
 
-		// Only the last component keeps the test-wide links, so they are reported once.
-		if i < len(split)-1 {
-			for _, key := range testWideMetadataKeys {
-				delete(metadata, key)
-			}
-		}
-
 		metadata["package-manager"] = targets[i].packageManager
 		metadata["project-name"] = targets[i].projectName
 		metadata["display-target-file"] = targets[i].displayTargetFile
@@ -134,9 +107,6 @@ func componentTestResults(
 	return results
 }
 
-// summarizeFindings counts findings by severity. When effective is true, findings suppressed
-// by policy are left out, matching the distinction the test API draws between its effective
-// and raw summaries.
 func summarizeFindings(findings []testapi.FindingData, effective bool) *testapi.FindingSummary {
 	bySeverity := map[string]uint32{}
 	var count uint32
@@ -163,7 +133,6 @@ func isSuppressed(finding testapi.FindingData) bool {
 		finding.Attributes.Suppression.Status == testapi.SuppressionStatusIgnored
 }
 
-// resultMetadata returns the metadata recorded on a test result, or nil if it has none.
 func resultMetadata(result testapi.TestResult) map[string]interface{} {
 	metadata, ok := result.Get(testapi.TestResultMetadata).(map[string]interface{})
 	if !ok {

--- a/internal/commands/ostest/component_test_result.go
+++ b/internal/commands/ostest/component_test_result.go
@@ -1,0 +1,170 @@
+package ostest
+
+import (
+	"context"
+	"maps"
+
+	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
+)
+
+// Metadata keys that describe the test run as a whole rather than any one component. They
+// are rendered once, on the last component, so that splitting a test's results does not
+// repeat the same link under every component.
+var testWideMetadataKeys = []string{"asset", "report-url"}
+
+// componentTestResult presents a single component of a test as a test result in its own right.
+//
+// The test API reports an SBOM test as one test covering many components, but the unified
+// findings presenter renders one section per test result. Wrapping each component as its own
+// result gives SBOM tests the same per-project output as `snyk test --all-projects`, where
+// every project genuinely is a separate test.
+//
+// Everything not scoped to a component is delegated to the underlying test result.
+type componentTestResult struct {
+	testapi.TestResult
+
+	findings   []testapi.FindingData
+	components []testapi.TestComponent
+	metadata   map[string]interface{}
+	effective  *testapi.FindingSummary
+	raw        *testapi.FindingSummary
+}
+
+// newComponentTestResult wraps result as the test result for a single component.
+func newComponentTestResult(
+	result testapi.TestResult,
+	component ComponentFindings,
+	metadata map[string]interface{},
+) *componentTestResult {
+	componentResult := &componentTestResult{
+		TestResult: result,
+		findings:   component.Findings,
+		metadata:   metadata,
+		effective:  summarizeFindings(component.Findings, true),
+		raw:        summarizeFindings(component.Findings, false),
+	}
+
+	if component.Key != "" {
+		componentResult.components = []testapi.TestComponent{{
+			Key:       component.Key,
+			ScanType:  testapi.FindingTypeSca,
+			ProjectId: component.ProjectID,
+		}}
+	}
+
+	return componentResult
+}
+
+func (c *componentTestResult) Findings(context.Context) ([]testapi.FindingData, bool, error) {
+	return c.findings, true, nil
+}
+
+func (c *componentTestResult) Get(key testapi.TestResultKeys) interface{} {
+	switch key {
+	case testapi.TestResultMetadata:
+		return c.metadata
+	case testapi.TestResultComponents:
+		if c.components == nil {
+			return nil
+		}
+		return &c.components
+	case testapi.TestResultRawSummary:
+		return c.raw
+	default:
+		return c.TestResult.Get(key)
+	}
+}
+
+func (c *componentTestResult) GetMetadata() map[string]interface{} {
+	return c.metadata
+}
+
+func (c *componentTestResult) GetMetadataValue(key string) interface{} {
+	return c.metadata[key]
+}
+
+func (c *componentTestResult) SetMetadata(key string, value interface{}) {
+	c.metadata[key] = value
+}
+
+func (c *componentTestResult) GetEffectiveSummary() *testapi.FindingSummary {
+	return c.effective
+}
+
+func (c *componentTestResult) GetRawSummary() *testapi.FindingSummary {
+	return c.raw
+}
+
+// componentTestResults wraps each component as its own test result. Component metadata is
+// derived from the base metadata so that anything the flow set on the test as a whole, such
+// as the package manager, is carried over.
+func componentTestResults(
+	result testapi.TestResult,
+	split []ComponentFindings,
+	targets []testTarget,
+	targetDir string,
+) []testapi.TestResult {
+	baseMetadata := resultMetadata(result)
+
+	results := make([]testapi.TestResult, 0, len(split))
+	for i := range split {
+		metadata := maps.Clone(baseMetadata)
+		if metadata == nil {
+			metadata = map[string]interface{}{}
+		}
+
+		// Only the last component keeps the test-wide links, so they render once.
+		if i < len(split)-1 {
+			for _, key := range testWideMetadataKeys {
+				delete(metadata, key)
+			}
+		}
+
+		metadata["package-manager"] = targets[i].packageManager
+		metadata["project-name"] = targets[i].projectName
+		metadata["display-target-file"] = targets[i].displayTargetFile
+		metadata["target-directory"] = targetDir
+		metadata["dependency-count"] = targets[i].depCount
+
+		results = append(results, newComponentTestResult(result, split[i], metadata))
+	}
+	return results
+}
+
+// summarizeFindings counts findings by severity. When effective is true, findings suppressed
+// by policy are left out, matching the distinction the test API draws between its effective
+// and raw summaries.
+func summarizeFindings(findings []testapi.FindingData, effective bool) *testapi.FindingSummary {
+	bySeverity := map[string]uint32{}
+	var count uint32
+
+	for _, finding := range findings {
+		if finding.Attributes == nil {
+			continue
+		}
+		if effective && isSuppressed(finding) {
+			continue
+		}
+		count++
+		bySeverity[string(finding.Attributes.Rating.Severity)]++
+	}
+
+	return &testapi.FindingSummary{
+		Count:   count,
+		CountBy: &map[string]map[string]uint32{"severity": bySeverity},
+	}
+}
+
+func isSuppressed(finding testapi.FindingData) bool {
+	return finding.Attributes.Suppression != nil &&
+		finding.Attributes.Suppression.Status == testapi.SuppressionStatusIgnored
+}
+
+// resultMetadata returns the metadata recorded on a test result, or nil if it has none.
+func resultMetadata(result testapi.TestResult) map[string]interface{} {
+	metadata, ok := result.Get(testapi.TestResultMetadata).(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return metadata
+}

--- a/internal/commands/ostest/components.go
+++ b/internal/commands/ostest/components.go
@@ -1,0 +1,118 @@
+package ostest
+
+import (
+	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
+
+	"github.com/snyk/cli-extension-os-flows/internal/util"
+)
+
+// ComponentFindings holds the findings belonging to a single component of a test.
+//
+// A test run against an SBOM covers every component in that document, but the test
+// API reports the whole run as a single test. Splitting the findings back out per
+// component lets the SBOM flow report one result per component, matching how
+// `snyk test --all-projects` reports one result per project.
+type ComponentFindings struct {
+	// Key is the test-scoped component key. It is empty for findings the test API
+	// did not attribute to any component.
+	Key string
+	// ProjectID is the Snyk project associated with the component, if any.
+	ProjectID *string
+	// Findings are the findings that originated in the component.
+	Findings []testapi.FindingData
+}
+
+// SplitFindingsByComponent groups findings by the component they originated in.
+//
+// The components reported on the test result are the canonical, ordered list, so a
+// component without findings still gets an entry and therefore still gets its own
+// result. Component keys seen only on a finding are appended afterwards, followed by
+// any findings that carry no component key at all.
+//
+// It returns nil when the test result carries no component information, in which case
+// the caller should report the findings as a single, unsplit result.
+func SplitFindingsByComponent(result testapi.TestResult, findings []testapi.FindingData) []ComponentFindings {
+	byKey := make(map[string][]testapi.FindingData, len(findings))
+	var keyOrder []string
+	for _, finding := range findings {
+		key := findingComponentKey(finding)
+		if _, ok := byKey[key]; !ok {
+			keyOrder = append(keyOrder, key)
+		}
+		byKey[key] = append(byKey[key], finding)
+	}
+
+	components := testResultComponents(result)
+	if len(components) == 0 && !hasComponentKey(keyOrder) {
+		return nil
+	}
+
+	split := make([]ComponentFindings, 0, len(components)+len(keyOrder))
+	seen := make(map[string]bool, len(components))
+
+	// A single component may be reported once per scan type, so de-duplicate by key.
+	for _, component := range components {
+		if component.Key == "" || seen[component.Key] {
+			continue
+		}
+		seen[component.Key] = true
+		split = append(split, ComponentFindings{
+			Key:       component.Key,
+			ProjectID: componentProjectID(component),
+			Findings:  byKey[component.Key],
+		})
+	}
+
+	for _, key := range keyOrder {
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		split = append(split, ComponentFindings{Key: key, Findings: byKey[key]})
+	}
+
+	// Report unattributed findings last, under the flow's own target file, rather
+	// than dropping them.
+	if unattributed := byKey[""]; len(unattributed) > 0 {
+		split = append(split, ComponentFindings{Findings: unattributed})
+	}
+
+	if len(split) == 0 {
+		return nil
+	}
+	return split
+}
+
+func hasComponentKey(keys []string) bool {
+	for _, key := range keys {
+		if key != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func findingComponentKey(finding testapi.FindingData) string {
+	if finding.Attributes == nil || finding.Attributes.ComponentKey == nil {
+		return ""
+	}
+	return *finding.Attributes.ComponentKey
+}
+
+func testResultComponents(result testapi.TestResult) []testapi.TestComponent {
+	if result == nil {
+		return nil
+	}
+	components, ok := result.Get(testapi.TestResultComponents).(*[]testapi.TestComponent)
+	if !ok || components == nil {
+		return nil
+	}
+	return *components
+}
+
+func componentProjectID(component testapi.TestComponent) *string {
+	if component.ProjectId == nil {
+		return nil
+	}
+	return util.Ptr(component.ProjectId.String())
+}

--- a/internal/commands/ostest/components.go
+++ b/internal/commands/ostest/components.go
@@ -1,9 +1,8 @@
 package ostest
 
 import (
+	"github.com/google/uuid"
 	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
-
-	"github.com/snyk/cli-extension-os-flows/internal/util"
 )
 
 // ComponentFindings holds the findings belonging to a single component of a test.
@@ -17,7 +16,7 @@ type ComponentFindings struct {
 	// did not attribute to any component.
 	Key string
 	// ProjectID is the Snyk project associated with the component, if any.
-	ProjectID *string
+	ProjectID *uuid.UUID
 	// Findings are the findings that originated in the component.
 	Findings []testapi.FindingData
 }
@@ -58,7 +57,7 @@ func SplitFindingsByComponent(result testapi.TestResult, findings []testapi.Find
 		seen[component.Key] = true
 		split = append(split, ComponentFindings{
 			Key:       component.Key,
-			ProjectID: componentProjectID(component),
+			ProjectID: component.ProjectId,
 			Findings:  byKey[component.Key],
 		})
 	}
@@ -110,9 +109,11 @@ func testResultComponents(result testapi.TestResult) []testapi.TestComponent {
 	return *components
 }
 
-func componentProjectID(component testapi.TestComponent) *string {
-	if component.ProjectId == nil {
-		return nil
+// componentKeys lists the keys of the split components, for logging.
+func componentKeys(split []ComponentFindings) []string {
+	keys := make([]string, 0, len(split))
+	for _, component := range split {
+		keys = append(keys, component.Key)
 	}
-	return util.Ptr(component.ProjectId.String())
+	return keys
 }

--- a/internal/commands/ostest/components.go
+++ b/internal/commands/ostest/components.go
@@ -6,30 +6,13 @@ import (
 )
 
 // ComponentFindings holds the findings belonging to a single component of a test.
-//
-// A test run against an SBOM covers every component in that document, but the test
-// API reports the whole run as a single test. Splitting the findings back out per
-// component lets the SBOM flow report one result per component, matching how
-// `snyk test --all-projects` reports one result per project.
 type ComponentFindings struct {
-	// Key is the test-scoped component key. It is empty for findings the test API
-	// did not attribute to any component.
-	Key string
-	// ProjectID is the Snyk project associated with the component, if any.
+	Key       string
 	ProjectID *uuid.UUID
-	// Findings are the findings that originated in the component.
-	Findings []testapi.FindingData
+	Findings  []testapi.FindingData
 }
 
 // SplitFindingsByComponent groups findings by the component they originated in.
-//
-// The components reported on the test result are the canonical, ordered list, so a
-// component without findings still gets an entry and therefore still gets its own
-// result. Component keys seen only on a finding are appended afterwards, followed by
-// any findings that carry no component key at all.
-//
-// It returns nil when the test result carries no component information, in which case
-// the caller should report the findings as a single, unsplit result.
 func SplitFindingsByComponent(result testapi.TestResult, findings []testapi.FindingData) []ComponentFindings {
 	byKey := make(map[string][]testapi.FindingData, len(findings))
 	var keyOrder []string
@@ -49,7 +32,6 @@ func SplitFindingsByComponent(result testapi.TestResult, findings []testapi.Find
 	split := make([]ComponentFindings, 0, len(components)+len(keyOrder))
 	seen := make(map[string]bool, len(components))
 
-	// A single component may be reported once per scan type, so de-duplicate by key.
 	for _, component := range components {
 		if component.Key == "" || seen[component.Key] {
 			continue
@@ -70,8 +52,6 @@ func SplitFindingsByComponent(result testapi.TestResult, findings []testapi.Find
 		split = append(split, ComponentFindings{Key: key, Findings: byKey[key]})
 	}
 
-	// Report unattributed findings last, under the flow's own target file, rather
-	// than dropping them.
 	if unattributed := byKey[""]; len(unattributed) > 0 {
 		split = append(split, ComponentFindings{Findings: unattributed})
 	}
@@ -109,7 +89,6 @@ func testResultComponents(result testapi.TestResult) []testapi.TestComponent {
 	return *components
 }
 
-// componentKeys lists the keys of the split components, for logging.
 func componentKeys(split []ComponentFindings) []string {
 	keys := make([]string, 0, len(split))
 	for _, component := range split {

--- a/internal/commands/ostest/components_test.go
+++ b/internal/commands/ostest/components_test.go
@@ -69,7 +69,7 @@ func Test_SplitFindingsByComponent_GroupsByComponentKey(t *testing.T) {
 	assert.Equal(t, "pkg:npm/app-a@1.0.0", split[0].Key)
 	assert.Equal(t, []string{"a1", "a2"}, titlesOf(split[0].Findings))
 	require.NotNil(t, split[0].ProjectID)
-	assert.Equal(t, projectID.String(), *split[0].ProjectID)
+	assert.Equal(t, projectID, *split[0].ProjectID)
 
 	assert.Equal(t, "pkg:npm/app-b@2.0.0", split[1].Key)
 	assert.Equal(t, []string{"b1"}, titlesOf(split[1].Findings))

--- a/internal/commands/ostest/components_test.go
+++ b/internal/commands/ostest/components_test.go
@@ -1,0 +1,190 @@
+package ostest_test
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	gafclientmocks "github.com/snyk/go-application-framework/pkg/apiclients/mocks"
+	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-os-flows/internal/commands/ostest"
+	"github.com/snyk/cli-extension-os-flows/internal/util"
+)
+
+// findingInComponent builds a finding attributed to the given component key. An empty key
+// produces a finding the test API did not attribute to any component.
+func findingInComponent(title, componentKey string) testapi.FindingData {
+	attrs := &testapi.FindingAttributes{Title: title}
+	if componentKey != "" {
+		attrs.ComponentKey = util.Ptr(componentKey)
+	}
+	return testapi.FindingData{Attributes: attrs}
+}
+
+// resultWithComponents builds a test result reporting the given components.
+func resultWithComponents(t *testing.T, components ...testapi.TestComponent) testapi.TestResult {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	result := gafclientmocks.NewMockTestResult(ctrl)
+	result.EXPECT().Get(testapi.TestResultComponents).Return(&components).AnyTimes()
+	return result
+}
+
+func scaComponent(key string, projectID *uuid.UUID) testapi.TestComponent {
+	return testapi.TestComponent{
+		Key:       key,
+		ProjectId: projectID,
+		ScanType:  testapi.FindingType("sca"),
+	}
+}
+
+func titlesOf(findings []testapi.FindingData) []string {
+	titles := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		titles = append(titles, finding.Attributes.Title)
+	}
+	return titles
+}
+
+func Test_SplitFindingsByComponent_GroupsByComponentKey(t *testing.T) {
+	projectID := uuid.New()
+	result := resultWithComponents(t,
+		scaComponent("pkg:npm/app-a@1.0.0", &projectID),
+		scaComponent("pkg:npm/app-b@2.0.0", nil),
+	)
+	findings := []testapi.FindingData{
+		findingInComponent("a1", "pkg:npm/app-a@1.0.0"),
+		findingInComponent("b1", "pkg:npm/app-b@2.0.0"),
+		findingInComponent("a2", "pkg:npm/app-a@1.0.0"),
+	}
+
+	split := ostest.SplitFindingsByComponent(result, findings)
+
+	require.Len(t, split, 2)
+
+	assert.Equal(t, "pkg:npm/app-a@1.0.0", split[0].Key)
+	assert.Equal(t, []string{"a1", "a2"}, titlesOf(split[0].Findings))
+	require.NotNil(t, split[0].ProjectID)
+	assert.Equal(t, projectID.String(), *split[0].ProjectID)
+
+	assert.Equal(t, "pkg:npm/app-b@2.0.0", split[1].Key)
+	assert.Equal(t, []string{"b1"}, titlesOf(split[1].Findings))
+	assert.Nil(t, split[1].ProjectID)
+}
+
+func Test_SplitFindingsByComponent_KeepsComponentsWithoutFindings(t *testing.T) {
+	result := resultWithComponents(t,
+		scaComponent("pkg:npm/vulnerable@1.0.0", nil),
+		scaComponent("pkg:npm/clean@1.0.0", nil),
+	)
+	findings := []testapi.FindingData{findingInComponent("only-one", "pkg:npm/vulnerable@1.0.0")}
+
+	split := ostest.SplitFindingsByComponent(result, findings)
+
+	require.Len(t, split, 2)
+	assert.Equal(t, "pkg:npm/clean@1.0.0", split[1].Key)
+	assert.Empty(t, split[1].Findings)
+}
+
+func Test_SplitFindingsByComponent_OrdersByReportedComponents(t *testing.T) {
+	// The findings arrive in the opposite order to the reported components.
+	result := resultWithComponents(t,
+		scaComponent("first", nil),
+		scaComponent("second", nil),
+	)
+	findings := []testapi.FindingData{
+		findingInComponent("s", "second"),
+		findingInComponent("f", "first"),
+	}
+
+	split := ostest.SplitFindingsByComponent(result, findings)
+
+	require.Len(t, split, 2)
+	assert.Equal(t, "first", split[0].Key)
+	assert.Equal(t, "second", split[1].Key)
+}
+
+func Test_SplitFindingsByComponent_AppendsKeysMissingFromTestResult(t *testing.T) {
+	result := resultWithComponents(t, scaComponent("reported", nil))
+	findings := []testapi.FindingData{
+		findingInComponent("u", "unreported"),
+		findingInComponent("r", "reported"),
+	}
+
+	split := ostest.SplitFindingsByComponent(result, findings)
+
+	require.Len(t, split, 2)
+	assert.Equal(t, "reported", split[0].Key)
+	assert.Equal(t, "unreported", split[1].Key)
+	assert.Equal(t, []string{"u"}, titlesOf(split[1].Findings))
+}
+
+func Test_SplitFindingsByComponent_ReportsUnattributedFindingsLast(t *testing.T) {
+	result := resultWithComponents(t, scaComponent("known", nil))
+	findings := []testapi.FindingData{
+		findingInComponent("orphan", ""),
+		findingInComponent("attributed", "known"),
+	}
+
+	split := ostest.SplitFindingsByComponent(result, findings)
+
+	require.Len(t, split, 2)
+	assert.Equal(t, "known", split[0].Key)
+	assert.Empty(t, split[1].Key)
+	assert.Equal(t, []string{"orphan"}, titlesOf(split[1].Findings))
+}
+
+func Test_SplitFindingsByComponent_DeduplicatesRepeatedComponentKeys(t *testing.T) {
+	// The same component can be reported once per scan type.
+	result := resultWithComponents(t,
+		scaComponent("shared", nil),
+		testapi.TestComponent{Key: "shared", ScanType: testapi.FindingType("sast")},
+	)
+	findings := []testapi.FindingData{findingInComponent("one", "shared")}
+
+	split := ostest.SplitFindingsByComponent(result, findings)
+
+	require.Len(t, split, 1)
+	assert.Equal(t, []string{"one"}, titlesOf(split[0].Findings))
+}
+
+func Test_SplitFindingsByComponent_NoComponentInformation(t *testing.T) {
+	tests := map[string]struct {
+		result   testapi.TestResult
+		findings []testapi.FindingData
+	}{
+		"no components and no component keys": {
+			result:   resultWithComponents(t),
+			findings: []testapi.FindingData{findingInComponent("a", ""), findingInComponent("b", "")},
+		},
+		"no findings at all": {
+			result:   resultWithComponents(t),
+			findings: nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// nil signals the caller to report a single, unsplit result.
+			assert.Nil(t, ostest.SplitFindingsByComponent(tc.result, tc.findings))
+		})
+	}
+}
+
+func Test_SplitFindingsByComponent_NilComponentsOnResult(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	result := gafclientmocks.NewMockTestResult(ctrl)
+	result.EXPECT().Get(testapi.TestResultComponents).Return(nil).AnyTimes()
+
+	findings := []testapi.FindingData{findingInComponent("a", "pkg:npm/app@1.0.0")}
+
+	split := ostest.SplitFindingsByComponent(result, findings)
+
+	// The component key on the finding is enough to split on.
+	require.Len(t, split, 1)
+	assert.Equal(t, "pkg:npm/app@1.0.0", split[0].Key)
+}

--- a/internal/commands/ostest/components_test.go
+++ b/internal/commands/ostest/components_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/snyk/cli-extension-os-flows/internal/util"
 )
 
-// findingInComponent builds a finding attributed to the given component key. An empty key
-// produces a finding the test API did not attribute to any component.
 func findingInComponent(title, componentKey string) testapi.FindingData {
 	attrs := &testapi.FindingAttributes{Title: title}
 	if componentKey != "" {
@@ -24,7 +22,6 @@ func findingInComponent(title, componentKey string) testapi.FindingData {
 	return testapi.FindingData{Attributes: attrs}
 }
 
-// resultWithComponents builds a test result reporting the given components.
 func resultWithComponents(t *testing.T, components ...testapi.TestComponent) testapi.TestResult {
 	t.Helper()
 
@@ -91,7 +88,6 @@ func Test_SplitFindingsByComponent_KeepsComponentsWithoutFindings(t *testing.T) 
 }
 
 func Test_SplitFindingsByComponent_OrdersByReportedComponents(t *testing.T) {
-	// The findings arrive in the opposite order to the reported components.
 	result := resultWithComponents(t,
 		scaComponent("first", nil),
 		scaComponent("second", nil),
@@ -139,7 +135,6 @@ func Test_SplitFindingsByComponent_ReportsUnattributedFindingsLast(t *testing.T)
 }
 
 func Test_SplitFindingsByComponent_DeduplicatesRepeatedComponentKeys(t *testing.T) {
-	// The same component can be reported once per scan type.
 	result := resultWithComponents(t,
 		scaComponent("shared", nil),
 		testapi.TestComponent{Key: "shared", ScanType: testapi.FindingType("sast")},
@@ -169,7 +164,6 @@ func Test_SplitFindingsByComponent_NoComponentInformation(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			// nil signals the caller to report a single, unsplit result.
 			assert.Nil(t, ostest.SplitFindingsByComponent(tc.result, tc.findings))
 		})
 	}
@@ -184,7 +178,6 @@ func Test_SplitFindingsByComponent_NilComponentsOnResult(t *testing.T) {
 
 	split := ostest.SplitFindingsByComponent(result, findings)
 
-	// The component key on the finding is enough to split on.
 	require.Len(t, split, 1)
 	assert.Equal(t, "pkg:npm/app@1.0.0", split[0].Key)
 }

--- a/internal/commands/ostest/sbom_components_test.go
+++ b/internal/commands/ostest/sbom_components_test.go
@@ -94,15 +94,23 @@ func setupMultiComponentSbomTest(
 	result.EXPECT().GetOutcomeReason().Return(util.Ptr(testapi.TestOutcomeReasonOther)).AnyTimes()
 	result.EXPECT().GetEffectiveSummary().Return(summary).AnyTimes()
 	result.EXPECT().GetRawSummary().Return(summary).AnyTimes()
-	result.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).Return().AnyTimes()
-	result.EXPECT().GetMetadata().Return(map[string]interface{}{}).AnyTimes()
-	result.EXPECT().GetMetadataValue(gomock.Any()).Return(nil).AnyTimes()
+	// Mirror the real test result, which stores metadata set on it.
+	metadata := map[string]interface{}{}
+	result.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).DoAndReturn(func(key string, value interface{}) {
+		metadata[key] = value
+	}).AnyTimes()
+	result.EXPECT().GetMetadata().Return(metadata).AnyTimes()
+	result.EXPECT().GetMetadataValue(gomock.Any()).DoAndReturn(func(key string) interface{} {
+		return metadata[key]
+	}).AnyTimes()
 	result.EXPECT().Get(testapi.TestResultTestSubject).Return(nil).AnyTimes()
 	result.EXPECT().Get(testapi.TestResultSubjectLocators).Return(nil).AnyTimes()
 	result.EXPECT().Get(testapi.TestResultBreachedPolicies).Return(&testapi.PolicyRefSet{}).AnyTimes()
 	result.EXPECT().Get(testapi.TestResultRawSummary).Return(summary).AnyTimes()
 	result.EXPECT().Get(testapi.TestResultTestFacts).Return(nil).AnyTimes()
-	result.EXPECT().Get(testapi.TestResultMetadata).Return(map[string]interface{}{}).AnyTimes()
+	result.EXPECT().Get(testapi.TestResultMetadata).DoAndReturn(func(testapi.TestResultKeys) interface{} {
+		return metadata
+	}).AnyTimes()
 	result.EXPECT().Get(testapi.TestResultComponents).Return(&components).AnyTimes()
 
 	handle := gafclientmocks.NewMockTestHandle(ctrl)
@@ -200,9 +208,29 @@ func Test_RunSbomFlow_SplitsHumanReadableResultsByComponent(t *testing.T) {
 	assert.Equal(t, []string{"b1"}, titlesOf(findingsByComponent[1]))
 	assert.Empty(t, findingsByComponent[2], "a component without findings still gets its own result")
 
-	// The test result describes the whole run and is emitted exactly once, last.
+	// The unified findings presenter renders one section per test result, so each component
+	// is presented as its own test result carrying its own metadata.
 	testResults := ufm.GetTestResultsFromWorkflowData(outputData[len(outputData)-1])
-	require.Len(t, testResults, 1)
+	require.Len(t, testResults, 3)
+
+	for i, key := range []string{appA, appB, clean} {
+		metadata, ok := testResults[i].Get(testapi.TestResultMetadata).(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, key, metadata["display-target-file"])
+		assert.Equal(t, "testdata", metadata["target-directory"], "the SBOM's directory is shared by every component")
+		// Per-component dependency counts are not available from the test API.
+		assert.EqualValues(t, 0, metadata["dependency-count"])
+	}
+
+	perComponentFindings := make([][]testapi.FindingData, 0, len(testResults))
+	for _, result := range testResults {
+		f, _, findingsErr := result.Findings(t.Context())
+		require.NoError(t, findingsErr)
+		perComponentFindings = append(perComponentFindings, f)
+	}
+	assert.Equal(t, []string{"a1", "a2"}, titlesOf(perComponentFindings[0]))
+	assert.Equal(t, []string{"b1"}, titlesOf(perComponentFindings[1]))
+	assert.Empty(t, perComponentFindings[2])
 }
 
 func Test_RunSbomFlow_SplitsLegacyJSONByComponent(t *testing.T) {
@@ -267,7 +295,7 @@ func Test_RunSbomFlow_SingleResultWhenNoComponentsReported(t *testing.T) {
 		[]testapi.FindingData{finding},
 	)
 
-	legacyJSON, _, err := common.RunSbomFlow(
+	legacyJSON, outputData, err := common.RunSbomFlow(
 		sbomTestContext(t, ictx),
 		multiComponentSbomPath,
 		common.FlowClients{TestClient: testClient, FileUploadClient: ffc, DeeproxyClient: fdc},
@@ -282,6 +310,12 @@ func Test_RunSbomFlow_SingleResultWhenNoComponentsReported(t *testing.T) {
 	require.Len(t, legacyJSON, 1)
 	assert.Equal(t, multiComponentSbomPath, legacyJSON[0].DisplayTargetFile)
 	assert.Nil(t, legacyJSON[0].ProjectName)
+
+	testResults := ufm.GetTestResultsFromWorkflowData(outputData[len(outputData)-1])
+	require.Len(t, testResults, 1)
+	metadata, ok := testResults[0].Get(testapi.TestResultMetadata).(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, multiComponentSbomPath, metadata["display-target-file"])
 }
 
 func unifiedSummariesFrom(t *testing.T, data []workflow.Data) []presenters.SummaryPayload {

--- a/internal/commands/ostest/sbom_components_test.go
+++ b/internal/commands/ostest/sbom_components_test.go
@@ -70,13 +70,15 @@ func componentFinding(t *testing.T, title, componentKey string) testapi.FindingD
 }
 
 // setupMultiComponentSbomTest wires up an SBOM test whose single test result reports the
-// given components and findings.
+// given components and findings. Any metadata is set on the test result as the test API
+// would report it, before the flow adds its own.
 func setupMultiComponentSbomTest(
 	t *testing.T,
 	ctrl *gomock.Controller,
 	jsonOutput bool,
 	components []testapi.TestComponent,
 	findings []testapi.FindingData,
+	metadata map[string]interface{},
 ) (*gafmocks.MockInvocationContext, testapi.TestClient, *fileupload.FakeClient, deeproxy.Client, uuid.UUID) {
 	t.Helper()
 
@@ -95,7 +97,9 @@ func setupMultiComponentSbomTest(
 	result.EXPECT().GetEffectiveSummary().Return(summary).AnyTimes()
 	result.EXPECT().GetRawSummary().Return(summary).AnyTimes()
 	// Mirror the real test result, which stores metadata set on it.
-	metadata := map[string]interface{}{}
+	if metadata == nil {
+		metadata = map[string]interface{}{}
+	}
 	result.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).DoAndReturn(func(key string, value interface{}) {
 		metadata[key] = value
 	}).AnyTimes()
@@ -168,6 +172,7 @@ func Test_RunSbomFlow_SplitsHumanReadableResultsByComponent(t *testing.T) {
 			componentFinding(t, "b1", appB),
 			componentFinding(t, "a2", appA),
 		},
+		nil,
 	)
 
 	_, outputData, err := common.RunSbomFlow(
@@ -250,6 +255,7 @@ func Test_RunSbomFlow_SplitsLegacyJSONByComponent(t *testing.T) {
 			componentFinding(t, "a1", appA),
 			componentFinding(t, "b1", appB),
 		},
+		nil,
 	)
 
 	legacyJSON, _, err := common.RunSbomFlow(
@@ -293,6 +299,7 @@ func Test_RunSbomFlow_SingleResultWhenNoComponentsReported(t *testing.T) {
 	ictx, testClient, ffc, fdc, orgID := setupMultiComponentSbomTest(t, ctrl, true,
 		[]testapi.TestComponent{},
 		[]testapi.FindingData{finding},
+		nil,
 	)
 
 	legacyJSON, outputData, err := common.RunSbomFlow(
@@ -316,6 +323,60 @@ func Test_RunSbomFlow_SingleResultWhenNoComponentsReported(t *testing.T) {
 	metadata, ok := testResults[0].Get(testapi.TestResultMetadata).(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, multiComponentSbomPath, metadata["display-target-file"])
+}
+
+func Test_RunSbomFlow_ReportsTestWideLinksOnce(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	appA := "pkg:npm/app-a@1.0.0"
+	appB := "pkg:npm/app-b@2.0.0"
+	assetLink := "https://app.snyk.io/asset/1234"
+	reportURL := "https://app.snyk.io/report/5678"
+
+	ictx, testClient, ffc, fdc, orgID := setupMultiComponentSbomTest(t, ctrl, false,
+		[]testapi.TestComponent{
+			{Key: appA, ScanType: testapi.FindingTypeSca},
+			{Key: appB, ScanType: testapi.FindingTypeSca},
+		},
+		[]testapi.FindingData{
+			componentFinding(t, "a1", appA),
+			componentFinding(t, "b1", appB),
+		},
+		map[string]interface{}{"asset": assetLink, "report-url": reportURL},
+	)
+
+	_, outputData, err := common.RunSbomFlow(
+		sbomTestContext(t, ictx),
+		multiComponentSbomPath,
+		common.FlowClients{TestClient: testClient, FileUploadClient: ffc, DeeproxyClient: fdc},
+		orgID,
+		nil,
+		nil,
+		ostest.RunTestWithResourcesByComponent,
+	)
+	require.NoError(t, err)
+
+	// The asset covers the test as a whole, so every component reports the same link and
+	// the presenter renders it once, below the overall test summary.
+	summaries := unifiedSummariesFrom(t, outputData)
+	require.Len(t, summaries, 2)
+	assert.Equal(t, assetLink, summaries[0].AssetLink)
+	assert.Equal(t, assetLink, summaries[1].AssetLink)
+
+	// The test-wide links are reported once in the test result metadata.
+	testResults := ufm.GetTestResultsFromWorkflowData(outputData[len(outputData)-1])
+	require.Len(t, testResults, 2)
+
+	first, ok := testResults[0].Get(testapi.TestResultMetadata).(map[string]interface{})
+	require.True(t, ok)
+	assert.NotContains(t, first, "asset")
+	assert.NotContains(t, first, "report-url")
+
+	last, ok := testResults[1].Get(testapi.TestResultMetadata).(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, assetLink, last["asset"])
+	assert.Equal(t, reportURL, last["report-url"])
 }
 
 func unifiedSummariesFrom(t *testing.T, data []workflow.Data) []presenters.SummaryPayload {

--- a/internal/commands/ostest/sbom_components_test.go
+++ b/internal/commands/ostest/sbom_components_test.go
@@ -32,7 +32,6 @@ import (
 
 const multiComponentSbomPath = "./testdata/bom.json"
 
-// componentFinding builds a minimal SCA finding attributed to a component.
 func componentFinding(t *testing.T, title, componentKey string) testapi.FindingData {
 	t.Helper()
 
@@ -69,9 +68,6 @@ func componentFinding(t *testing.T, title, componentKey string) testapi.FindingD
 	}
 }
 
-// setupMultiComponentSbomTest wires up an SBOM test whose single test result reports the
-// given components and findings. Any metadata is set on the test result as the test API
-// would report it, before the flow adds its own.
 func setupMultiComponentSbomTest(
 	t *testing.T,
 	ctrl *gomock.Controller,
@@ -96,7 +92,6 @@ func setupMultiComponentSbomTest(
 	result.EXPECT().GetOutcomeReason().Return(util.Ptr(testapi.TestOutcomeReasonOther)).AnyTimes()
 	result.EXPECT().GetEffectiveSummary().Return(summary).AnyTimes()
 	result.EXPECT().GetRawSummary().Return(summary).AnyTimes()
-	// Mirror the real test result, which stores metadata set on it.
 	if metadata == nil {
 		metadata = map[string]interface{}{}
 	}
@@ -186,14 +181,11 @@ func Test_RunSbomFlow_SplitsHumanReadableResultsByComponent(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Three components, each contributing a test summary, findings and unified summary,
-	// plus a single test result for the run as a whole.
 	require.Len(t, outputData, 10)
 
 	summaries := unifiedSummariesFrom(t, outputData)
 	require.Len(t, summaries, 3)
 
-	// Each component is reported under its own key, in the order the test result lists them.
 	assert.Equal(t, []string{appA, appB, clean}, []string{
 		summaries[0].DisplayTargetFile, summaries[1].DisplayTargetFile, summaries[2].DisplayTargetFile,
 	})
@@ -201,8 +193,6 @@ func Test_RunSbomFlow_SplitsHumanReadableResultsByComponent(t *testing.T) {
 		summaries[0].ProjectName, summaries[1].ProjectName, summaries[2].ProjectName,
 	})
 
-	// The test API only reports a test-wide dependency count, so it is left off the
-	// individual components.
 	for _, summary := range summaries {
 		assert.Zero(t, summary.DependencyCount)
 	}
@@ -213,8 +203,6 @@ func Test_RunSbomFlow_SplitsHumanReadableResultsByComponent(t *testing.T) {
 	assert.Equal(t, []string{"b1"}, titlesOf(findingsByComponent[1]))
 	assert.Empty(t, findingsByComponent[2], "a component without findings still gets its own result")
 
-	// The unified findings presenter renders one section per test result, so each component
-	// is presented as its own test result carrying its own metadata.
 	testResults := ufm.GetTestResultsFromWorkflowData(outputData[len(outputData)-1])
 	require.Len(t, testResults, 3)
 
@@ -223,7 +211,6 @@ func Test_RunSbomFlow_SplitsHumanReadableResultsByComponent(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, key, metadata["display-target-file"])
 		assert.Equal(t, "testdata", metadata["target-directory"], "the SBOM's directory is shared by every component")
-		// Per-component dependency counts are not available from the test API.
 		assert.EqualValues(t, 0, metadata["dependency-count"])
 	}
 
@@ -274,7 +261,6 @@ func Test_RunSbomFlow_SplitsLegacyJSONByComponent(t *testing.T) {
 	require.NotNil(t, legacyJSON[0].ProjectName)
 	assert.Equal(t, appA, *legacyJSON[0].ProjectName)
 	assert.Equal(t, appA, legacyJSON[0].DisplayTargetFile)
-	// The SBOM document itself stays the target file for every component.
 	require.NotNil(t, legacyJSON[0].TargetFile)
 	assert.Equal(t, multiComponentSbomPath, *legacyJSON[0].TargetFile)
 	require.NotNil(t, legacyJSON[0].ProjectId)
@@ -283,8 +269,6 @@ func Test_RunSbomFlow_SplitsLegacyJSONByComponent(t *testing.T) {
 
 	require.NotNil(t, legacyJSON[1].ProjectName)
 	assert.Equal(t, appB, *legacyJSON[1].ProjectName)
-	// The component has no project of its own, and the test-wide project belongs to no
-	// single component.
 	assert.Nil(t, legacyJSON[1].ProjectId)
 	assert.Len(t, legacyJSON[1].Vulnerabilities, 1)
 }
@@ -313,7 +297,6 @@ func Test_RunSbomFlow_SingleResultWhenNoComponentsReported(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Without component information the results are reported as one, as before.
 	require.Len(t, legacyJSON, 1)
 	assert.Equal(t, multiComponentSbomPath, legacyJSON[0].DisplayTargetFile)
 	assert.Nil(t, legacyJSON[0].ProjectName)
@@ -325,7 +308,7 @@ func Test_RunSbomFlow_SingleResultWhenNoComponentsReported(t *testing.T) {
 	assert.Equal(t, multiComponentSbomPath, metadata["display-target-file"])
 }
 
-func Test_RunSbomFlow_ReportsTestWideLinksOnce(t *testing.T) {
+func Test_RunSbomFlow_ReportsTheAssetOnEveryComponent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -357,26 +340,20 @@ func Test_RunSbomFlow_ReportsTestWideLinksOnce(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// The asset covers the test as a whole, so every component reports the same link and
-	// the presenter renders it once, below the overall test summary.
+	testResults := ufm.GetTestResultsFromWorkflowData(outputData[len(outputData)-1])
+	require.Len(t, testResults, 2)
+
+	for i := range testResults {
+		metadata, ok := testResults[i].Get(testapi.TestResultMetadata).(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, assetLink, metadata["asset"], "component %d", i)
+		assert.Equal(t, reportURL, metadata["report-url"], "component %d", i)
+	}
+
 	summaries := unifiedSummariesFrom(t, outputData)
 	require.Len(t, summaries, 2)
 	assert.Equal(t, assetLink, summaries[0].AssetLink)
 	assert.Equal(t, assetLink, summaries[1].AssetLink)
-
-	// The test-wide links are reported once in the test result metadata.
-	testResults := ufm.GetTestResultsFromWorkflowData(outputData[len(outputData)-1])
-	require.Len(t, testResults, 2)
-
-	first, ok := testResults[0].Get(testapi.TestResultMetadata).(map[string]interface{})
-	require.True(t, ok)
-	assert.NotContains(t, first, "asset")
-	assert.NotContains(t, first, "report-url")
-
-	last, ok := testResults[1].Get(testapi.TestResultMetadata).(map[string]interface{})
-	require.True(t, ok)
-	assert.Equal(t, assetLink, last["asset"])
-	assert.Equal(t, reportURL, last["report-url"])
 }
 
 func unifiedSummariesFrom(t *testing.T, data []workflow.Data) []presenters.SummaryPayload {

--- a/internal/commands/ostest/sbom_components_test.go
+++ b/internal/commands/ostest/sbom_components_test.go
@@ -1,0 +1,321 @@
+package ostest_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/snyk/go-application-framework/pkg/apiclients/fileupload"
+	gafclientmocks "github.com/snyk/go-application-framework/pkg/apiclients/mocks"
+	"github.com/snyk/go-application-framework/pkg/apiclients/testapi"
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	gafmocks "github.com/snyk/go-application-framework/pkg/mocks"
+	"github.com/snyk/go-application-framework/pkg/runtimeinfo"
+	"github.com/snyk/go-application-framework/pkg/utils/ufm"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/cli-extension-os-flows/internal/commands/cmdctx"
+	"github.com/snyk/cli-extension-os-flows/internal/commands/ostest"
+	"github.com/snyk/cli-extension-os-flows/internal/common"
+	"github.com/snyk/cli-extension-os-flows/internal/deeproxy"
+	"github.com/snyk/cli-extension-os-flows/internal/errors"
+	"github.com/snyk/cli-extension-os-flows/internal/outputworkflow"
+	"github.com/snyk/cli-extension-os-flows/internal/presenters"
+	"github.com/snyk/cli-extension-os-flows/internal/util"
+	"github.com/snyk/cli-extension-os-flows/internal/util/testfactories"
+)
+
+const multiComponentSbomPath = "./testdata/bom.json"
+
+// componentFinding builds a minimal SCA finding attributed to a component.
+func componentFinding(t *testing.T, title, componentKey string) testapi.FindingData {
+	t.Helper()
+
+	var problem testapi.Problem
+	ecosystem := testapi.SnykvulndbPackageEcosystem{}
+	require.NoError(t, ecosystem.FromSnykvulndbBuildPackageEcosystem(testapi.SnykvulndbBuildPackageEcosystem{
+		Language:       "js",
+		PackageManager: "npm",
+		Type:           testapi.Build,
+	}))
+	require.NoError(t, problem.FromSnykVulnProblem(testapi.SnykVulnProblem{
+		Id:             "snyk-vuln-" + title,
+		PackageName:    "foo",
+		PackageVersion: "0.0.0",
+		Ecosystem:      ecosystem,
+	}))
+
+	findingID := uuid.New()
+	findingType := testapi.Findings
+	return testapi.FindingData{
+		Id:   &findingID,
+		Type: &findingType,
+		Attributes: &testapi.FindingAttributes{
+			ComponentKey: util.Ptr(componentKey),
+			Description:  "description of " + title,
+			Evidence:     []testapi.Evidence{testfactories.NewShimDependencyPathEvidence(t, "root@1.0.0", "foo@0.0.0")},
+			FindingType:  testapi.FindingTypeSca,
+			Key:          "KEY-" + title,
+			Locations:    []testapi.FindingLocation{testfactories.NewShimPackageLocation(t, "foo@0.0.0")},
+			Problems:     []testapi.Problem{problem},
+			Rating:       testapi.Rating{Severity: testapi.SeverityHigh},
+			Title:        title,
+		},
+	}
+}
+
+// setupMultiComponentSbomTest wires up an SBOM test whose single test result reports the
+// given components and findings.
+func setupMultiComponentSbomTest(
+	t *testing.T,
+	ctrl *gomock.Controller,
+	jsonOutput bool,
+	components []testapi.TestComponent,
+	findings []testapi.FindingData,
+) (*gafmocks.MockInvocationContext, testapi.TestClient, *fileupload.FakeClient, deeproxy.Client, uuid.UUID) {
+	t.Helper()
+
+	summary := &testapi.FindingSummary{Count: uint32(len(findings))} //nolint:gosec // Small, test-controlled value.
+
+	result := gafclientmocks.NewMockTestResult(ctrl)
+	result.EXPECT().GetExecutionState().Return(testapi.TestExecutionStatesFinished).AnyTimes()
+	result.EXPECT().Findings(gomock.Any()).Return(findings, true, nil).AnyTimes()
+	result.EXPECT().GetTestID().Return(&uuid.UUID{}).AnyTimes()
+	result.EXPECT().GetTestConfiguration().Return(&testapi.TestConfiguration{}).AnyTimes()
+	result.EXPECT().GetCreatedAt().Return(&time.Time{}).AnyTimes()
+	result.EXPECT().GetErrors().Return(&[]testapi.IoSnykApiCommonError{}).AnyTimes()
+	result.EXPECT().GetWarnings().Return(&[]testapi.IoSnykApiCommonError{}).AnyTimes()
+	result.EXPECT().GetPassFail().Return(util.Ptr(testapi.Pass)).AnyTimes()
+	result.EXPECT().GetOutcomeReason().Return(util.Ptr(testapi.TestOutcomeReasonOther)).AnyTimes()
+	result.EXPECT().GetEffectiveSummary().Return(summary).AnyTimes()
+	result.EXPECT().GetRawSummary().Return(summary).AnyTimes()
+	result.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).Return().AnyTimes()
+	result.EXPECT().GetMetadata().Return(map[string]interface{}{}).AnyTimes()
+	result.EXPECT().GetMetadataValue(gomock.Any()).Return(nil).AnyTimes()
+	result.EXPECT().Get(testapi.TestResultTestSubject).Return(nil).AnyTimes()
+	result.EXPECT().Get(testapi.TestResultSubjectLocators).Return(nil).AnyTimes()
+	result.EXPECT().Get(testapi.TestResultBreachedPolicies).Return(&testapi.PolicyRefSet{}).AnyTimes()
+	result.EXPECT().Get(testapi.TestResultRawSummary).Return(summary).AnyTimes()
+	result.EXPECT().Get(testapi.TestResultTestFacts).Return(nil).AnyTimes()
+	result.EXPECT().Get(testapi.TestResultMetadata).Return(map[string]interface{}{}).AnyTimes()
+	result.EXPECT().Get(testapi.TestResultComponents).Return(&components).AnyTimes()
+
+	handle := gafclientmocks.NewMockTestHandle(ctrl)
+	handle.EXPECT().Wait(gomock.Any()).Return(nil).Times(1)
+	handle.EXPECT().Result().Return(result).Times(1)
+
+	client := gafclientmocks.NewMockTestClient(ctrl)
+	client.EXPECT().StartTest(gomock.Any(), gomock.Any()).Return(handle, nil).Times(1)
+
+	cfg := configuration.New()
+	cfg.Set(outputworkflow.OutputConfigKeyJSON, jsonOutput)
+	cfg.Set(configuration.ORGANIZATION_SLUG, "test-org-slug")
+
+	ui := gafmocks.NewMockUserInterface(ctrl)
+	ui.EXPECT().Output(gomock.Any()).Return(nil).AnyTimes()
+	ui.EXPECT().OutputError(gomock.Any()).Return(nil).AnyTimes()
+
+	ictx := gafmocks.NewMockInvocationContext(ctrl)
+	ictx.EXPECT().GetConfiguration().Return(cfg).AnyTimes()
+	ictx.EXPECT().GetEnhancedLogger().Return(&nopLogger).AnyTimes()
+	ictx.EXPECT().GetRuntimeInfo().Return(runtimeinfo.New()).AnyTimes()
+	ictx.EXPECT().GetWorkflowIdentifier().Return(workflow.NewWorkflowIdentifier("test")).AnyTimes()
+	ictx.EXPECT().GetUserInterface().Return(ui).AnyTimes()
+
+	return ictx, client, fileupload.NewFakeClient(), deeproxy.NewFakeClient(deeproxy.AllowList{}, nil), uuid.New()
+}
+
+func sbomTestContext(t *testing.T, ictx *gafmocks.MockInvocationContext) context.Context {
+	t.Helper()
+
+	c := cmdctx.WithIctx(t.Context(), ictx)
+	c = cmdctx.WithConfig(c, ictx.GetConfiguration())
+	c = cmdctx.WithLogger(c, &nopLogger)
+	c = cmdctx.WithErrorFactory(c, errors.NewErrorFactory(&nopLogger))
+	c = cmdctx.WithProgressBar(c, &nopProgressBar)
+	return c
+}
+
+func Test_RunSbomFlow_SplitsHumanReadableResultsByComponent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	appA := "pkg:npm/app-a@1.0.0"
+	appB := "pkg:npm/app-b@2.0.0"
+	clean := "pkg:npm/clean@3.0.0"
+
+	ictx, testClient, ffc, fdc, orgID := setupMultiComponentSbomTest(t, ctrl, false,
+		[]testapi.TestComponent{
+			{Key: appA, ScanType: testapi.FindingTypeSca},
+			{Key: appB, ScanType: testapi.FindingTypeSca},
+			{Key: clean, ScanType: testapi.FindingTypeSca},
+		},
+		[]testapi.FindingData{
+			componentFinding(t, "a1", appA),
+			componentFinding(t, "b1", appB),
+			componentFinding(t, "a2", appA),
+		},
+	)
+
+	_, outputData, err := common.RunSbomFlow(
+		sbomTestContext(t, ictx),
+		multiComponentSbomPath,
+		common.FlowClients{TestClient: testClient, FileUploadClient: ffc, DeeproxyClient: fdc},
+		orgID,
+		nil,
+		nil,
+		ostest.RunTestWithResourcesByComponent,
+	)
+	require.NoError(t, err)
+
+	// Three components, each contributing a test summary, findings and unified summary,
+	// plus a single test result for the run as a whole.
+	require.Len(t, outputData, 10)
+
+	summaries := unifiedSummariesFrom(t, outputData)
+	require.Len(t, summaries, 3)
+
+	// Each component is reported under its own key, in the order the test result lists them.
+	assert.Equal(t, []string{appA, appB, clean}, []string{
+		summaries[0].DisplayTargetFile, summaries[1].DisplayTargetFile, summaries[2].DisplayTargetFile,
+	})
+	assert.Equal(t, []string{appA, appB, clean}, []string{
+		summaries[0].ProjectName, summaries[1].ProjectName, summaries[2].ProjectName,
+	})
+
+	// The test API only reports a test-wide dependency count, so it is left off the
+	// individual components.
+	for _, summary := range summaries {
+		assert.Zero(t, summary.DependencyCount)
+	}
+
+	findingsByComponent := unifiedFindingsFrom(t, outputData)
+	require.Len(t, findingsByComponent, 3)
+	assert.Equal(t, []string{"a1", "a2"}, titlesOf(findingsByComponent[0]))
+	assert.Equal(t, []string{"b1"}, titlesOf(findingsByComponent[1]))
+	assert.Empty(t, findingsByComponent[2], "a component without findings still gets its own result")
+
+	// The test result describes the whole run and is emitted exactly once, last.
+	testResults := ufm.GetTestResultsFromWorkflowData(outputData[len(outputData)-1])
+	require.Len(t, testResults, 1)
+}
+
+func Test_RunSbomFlow_SplitsLegacyJSONByComponent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	appA := "pkg:npm/app-a@1.0.0"
+	appB := "pkg:npm/app-b@2.0.0"
+	projectA := uuid.New()
+
+	ictx, testClient, ffc, fdc, orgID := setupMultiComponentSbomTest(t, ctrl, true,
+		[]testapi.TestComponent{
+			{Key: appA, ProjectId: &projectA, ScanType: testapi.FindingTypeSca},
+			{Key: appB, ScanType: testapi.FindingTypeSca},
+		},
+		[]testapi.FindingData{
+			componentFinding(t, "a1", appA),
+			componentFinding(t, "b1", appB),
+		},
+	)
+
+	legacyJSON, _, err := common.RunSbomFlow(
+		sbomTestContext(t, ictx),
+		multiComponentSbomPath,
+		common.FlowClients{TestClient: testClient, FileUploadClient: ffc, DeeproxyClient: fdc},
+		orgID,
+		nil,
+		nil,
+		ostest.RunTestWithResourcesByComponent,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, legacyJSON, 2)
+
+	require.NotNil(t, legacyJSON[0].ProjectName)
+	assert.Equal(t, appA, *legacyJSON[0].ProjectName)
+	assert.Equal(t, appA, legacyJSON[0].DisplayTargetFile)
+	// The SBOM document itself stays the target file for every component.
+	require.NotNil(t, legacyJSON[0].TargetFile)
+	assert.Equal(t, multiComponentSbomPath, *legacyJSON[0].TargetFile)
+	require.NotNil(t, legacyJSON[0].ProjectId)
+	assert.Equal(t, projectA.String(), *legacyJSON[0].ProjectId)
+	assert.Len(t, legacyJSON[0].Vulnerabilities, 1)
+
+	require.NotNil(t, legacyJSON[1].ProjectName)
+	assert.Equal(t, appB, *legacyJSON[1].ProjectName)
+	// The component has no project of its own, and the test-wide project belongs to no
+	// single component.
+	assert.Nil(t, legacyJSON[1].ProjectId)
+	assert.Len(t, legacyJSON[1].Vulnerabilities, 1)
+}
+
+func Test_RunSbomFlow_SingleResultWhenNoComponentsReported(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	finding := componentFinding(t, "a1", "")
+	finding.Attributes.ComponentKey = nil
+
+	ictx, testClient, ffc, fdc, orgID := setupMultiComponentSbomTest(t, ctrl, true,
+		[]testapi.TestComponent{},
+		[]testapi.FindingData{finding},
+	)
+
+	legacyJSON, _, err := common.RunSbomFlow(
+		sbomTestContext(t, ictx),
+		multiComponentSbomPath,
+		common.FlowClients{TestClient: testClient, FileUploadClient: ffc, DeeproxyClient: fdc},
+		orgID,
+		nil,
+		nil,
+		ostest.RunTestWithResourcesByComponent,
+	)
+	require.NoError(t, err)
+
+	// Without component information the results are reported as one, as before.
+	require.Len(t, legacyJSON, 1)
+	assert.Equal(t, multiComponentSbomPath, legacyJSON[0].DisplayTargetFile)
+	assert.Nil(t, legacyJSON[0].ProjectName)
+}
+
+func unifiedSummariesFrom(t *testing.T, data []workflow.Data) []presenters.SummaryPayload {
+	t.Helper()
+
+	var summaries []presenters.SummaryPayload
+	for _, d := range data {
+		if d.GetContentType() != "application/json; schema=local-unified-summary" {
+			continue
+		}
+		payload, ok := d.GetPayload().([]byte)
+		require.True(t, ok)
+
+		var summary presenters.SummaryPayload
+		require.NoError(t, json.Unmarshal(payload, &summary))
+		summaries = append(summaries, summary)
+	}
+	return summaries
+}
+
+func unifiedFindingsFrom(t *testing.T, data []workflow.Data) [][]testapi.FindingData {
+	t.Helper()
+
+	var all [][]testapi.FindingData
+	for _, d := range data {
+		if d.GetContentType() != "application/json; schema=local-unified-finding" {
+			continue
+		}
+		payload, ok := d.GetPayload().([]byte)
+		require.True(t, ok)
+
+		var findings []testapi.FindingData
+		require.NoError(t, json.Unmarshal(payload, &findings))
+		all = append(all, findings)
+	}
+	return all
+}

--- a/internal/commands/ostest/sbom_flow_test.go
+++ b/internal/commands/ostest/sbom_flow_test.go
@@ -62,7 +62,7 @@ func Test_RunSbomFlow_Reachability_JSON(t *testing.T) {
 		common.FlowClients{TestClient: mockTestClient, FileUploadClient: ffc, DeeproxyClient: fdc},
 		orgID,
 		nil,
-		&common.ReachabilityOpts{SourceDir: sourceCodePath}, ostest.RunTestWithResources,
+		&common.ReachabilityOpts{SourceDir: sourceCodePath}, ostest.RunTestWithResourcesByComponent,
 	)
 	require.NoError(t, err)
 
@@ -107,13 +107,15 @@ func Test_RunSbomFlow_Reachability_HumanReadable(t *testing.T) {
 		common.FlowClients{TestClient: mockTestClient, FileUploadClient: ffc, DeeproxyClient: fdc},
 		orgID,
 		nil,
-		&common.ReachabilityOpts{SourceDir: sourceCodePath}, ostest.RunTestWithResources,
+		&common.ReachabilityOpts{SourceDir: sourceCodePath}, ostest.RunTestWithResourcesByComponent,
 	)
 	require.NoError(t, err)
 
 	require.Nil(t, legacyJSON)
 	require.NotNil(t, outputData)
-	// Output data should contain standard summary, unified model test result, local unified findings and local unified summary
+	// Output data should contain standard summary, local unified findings, local unified summary
+	// and the unified model test result. The test result comes last because it describes the
+	// whole test run rather than any one component.
 	require.Len(t, outputData, 4)
 
 	require.Contains(t, "application/json; schema=test-summary", outputData[0].GetContentType())
@@ -121,18 +123,18 @@ func Test_RunSbomFlow_Reachability_HumanReadable(t *testing.T) {
 	require.True(t, ok)
 	snaps.MatchJSON(t, summary)
 
-	testResult := ufm.GetTestResultsFromWorkflowData(outputData[1])
-	require.Len(t, testResult, 1)
-
-	require.Contains(t, "application/json; schema=local-unified-finding", outputData[2].GetContentType())
-	localFindings, ok := outputData[2].GetPayload().([]byte)
+	require.Contains(t, "application/json; schema=local-unified-finding", outputData[1].GetContentType())
+	localFindings, ok := outputData[1].GetPayload().([]byte)
 	require.True(t, ok)
 	snaps.MatchJSON(t, idRgxp.ReplaceAll(localFindings, nil))
 
-	require.Contains(t, "application/json; schema=local-unified-summary", outputData[3].GetContentType())
-	localSummary, ok := outputData[3].GetPayload().([]byte)
+	require.Contains(t, "application/json; schema=local-unified-summary", outputData[2].GetContentType())
+	localSummary, ok := outputData[2].GetPayload().([]byte)
 	require.True(t, ok)
 	snaps.MatchJSON(t, localSummary)
+
+	testResult := ufm.GetTestResultsFromWorkflowData(outputData[3])
+	require.Len(t, testResult, 1)
 
 	// Verify file upload client was called for both SBOM and source code
 	require.Equal(t, 2, ffc.GetUploadCount(), "Expected 2 uploads (SBOM + source code)")
@@ -158,7 +160,7 @@ func Test_RunSbomFlow_NoReachability_JSON(t *testing.T) {
 		common.FlowClients{TestClient: mockTestClient, FileUploadClient: ffc, DeeproxyClient: fdc},
 		orgID,
 		nil,
-		nil, ostest.RunTestWithResources,
+		nil, ostest.RunTestWithResourcesByComponent,
 	)
 	require.NoError(t, err)
 
@@ -203,13 +205,15 @@ func Test_RunSbomFlow_NoReachability_HumanReadable(t *testing.T) {
 		common.FlowClients{TestClient: mockTestClient, FileUploadClient: ffc, DeeproxyClient: fdc},
 		orgID,
 		nil,
-		nil, ostest.RunTestWithResources,
+		nil, ostest.RunTestWithResourcesByComponent,
 	)
 	require.NoError(t, err)
 
 	require.Nil(t, legacyJSON)
 	require.NotNil(t, outputData)
-	// Output data should contain standard summary, unified model test result, local unified findings and local unified summary
+	// Output data should contain standard summary, local unified findings, local unified summary
+	// and the unified model test result. The test result comes last because it describes the
+	// whole test run rather than any one component.
 	require.Len(t, outputData, 4)
 
 	require.Contains(t, "application/json; schema=test-summary", outputData[0].GetContentType())
@@ -217,18 +221,18 @@ func Test_RunSbomFlow_NoReachability_HumanReadable(t *testing.T) {
 	require.True(t, ok)
 	snaps.MatchJSON(t, summary)
 
-	testResult := ufm.GetTestResultsFromWorkflowData(outputData[1])
-	require.Len(t, testResult, 1)
-
-	require.Contains(t, "application/json; schema=local-unified-finding", outputData[2].GetContentType())
-	localFindings, ok := outputData[2].GetPayload().([]byte)
+	require.Contains(t, "application/json; schema=local-unified-finding", outputData[1].GetContentType())
+	localFindings, ok := outputData[1].GetPayload().([]byte)
 	require.True(t, ok)
 	snaps.MatchJSON(t, idRgxp.ReplaceAll(localFindings, nil))
 
-	require.Contains(t, "application/json; schema=local-unified-summary", outputData[3].GetContentType())
-	localSummary, ok := outputData[3].GetPayload().([]byte)
+	require.Contains(t, "application/json; schema=local-unified-summary", outputData[2].GetContentType())
+	localSummary, ok := outputData[2].GetPayload().([]byte)
 	require.True(t, ok)
 	snaps.MatchJSON(t, localSummary)
+
+	testResult := ufm.GetTestResultsFromWorkflowData(outputData[3])
+	require.Len(t, testResult, 1)
 
 	// Verify file upload client was called only for SBOM
 	require.Equal(t, 1, ffc.GetUploadCount(), "Expected 1 upload (SBOM only)")
@@ -257,14 +261,14 @@ func Test_RunSbomFlow_HumanReadable_PropagatesAssetLink(t *testing.T) {
 		orgID,
 		nil,
 		nil,
-		ostest.RunTestWithResources,
+		ostest.RunTestWithResourcesByComponent,
 	)
 	require.NoError(t, err)
 	require.NotNil(t, outputData)
 	require.Len(t, outputData, 4)
 
-	require.Contains(t, "application/json; schema=local-unified-summary", outputData[3].GetContentType())
-	localSummary, ok := outputData[3].GetPayload().([]byte)
+	require.Contains(t, "application/json; schema=local-unified-summary", outputData[2].GetContentType())
+	localSummary, ok := outputData[2].GetPayload().([]byte)
 	require.True(t, ok)
 
 	var payload presenters.SummaryPayload
@@ -295,7 +299,7 @@ func Test_RunSbomFlow_SkipsSourceUploadWhenNoSupportedSources(t *testing.T) {
 		common.FlowClients{TestClient: mockTestClient, FileUploadClient: ffc, DeeproxyClient: fdc},
 		orgID,
 		nil,
-		&common.ReachabilityOpts{SourceDir: sourceDir}, ostest.RunTestWithResources,
+		&common.ReachabilityOpts{SourceDir: sourceDir}, ostest.RunTestWithResourcesByComponent,
 	)
 	require.NoError(t, err)
 

--- a/internal/commands/ostest/sbom_flow_test.go
+++ b/internal/commands/ostest/sbom_flow_test.go
@@ -113,9 +113,6 @@ func Test_RunSbomFlow_Reachability_HumanReadable(t *testing.T) {
 
 	require.Nil(t, legacyJSON)
 	require.NotNil(t, outputData)
-	// Output data should contain standard summary, local unified findings, local unified summary
-	// and the unified model test result. The test result comes last because it describes the
-	// whole test run rather than any one component.
 	require.Len(t, outputData, 4)
 
 	require.Contains(t, "application/json; schema=test-summary", outputData[0].GetContentType())
@@ -211,9 +208,6 @@ func Test_RunSbomFlow_NoReachability_HumanReadable(t *testing.T) {
 
 	require.Nil(t, legacyJSON)
 	require.NotNil(t, outputData)
-	// Output data should contain standard summary, local unified findings, local unified summary
-	// and the unified model test result. The test result comes last because it describes the
-	// whole test run rather than any one component.
 	require.Len(t, outputData, 4)
 
 	require.Contains(t, "application/json; schema=test-summary", outputData[0].GetContentType())

--- a/internal/commands/ostest/test_execution.go
+++ b/internal/commands/ostest/test_execution.go
@@ -54,7 +54,7 @@ func RunTestWithSubject(
 ) (*definitions.LegacyVulnerabilityResponse, []workflow.Data, error) {
 	testConfig := testapi.TestConfiguration{LocalPolicy: localPolicy}
 	startParams := testapi.NewStartTestParamsFromSubject(orgID, &subject, &testConfig)
-	return runTestInternal(ctx, targetDir, testClient, startParams, projectName, packageManager, depCount, targetFile, displayTargetFile)
+	return runSingleTest(ctx, targetDir, testClient, startParams, projectName, packageManager, depCount, targetFile, displayTargetFile)
 }
 
 // RunTestWithResources executes the test flow with the provided test resources (for SBOM flows).
@@ -73,11 +73,53 @@ func RunTestWithResources(
 	testConfig *testapi.TestConfiguration,
 ) (*definitions.LegacyVulnerabilityResponse, []workflow.Data, error) {
 	startParams := testapi.NewStartTestParamsFromResources(orgID, &resources, testConfig)
-	return runTestInternal(ctx, targetDir, testClient, startParams, projectName, packageManager, depCount, targetFile, displayTargetFile)
+	return runSingleTest(ctx, targetDir, testClient, startParams, projectName, packageManager, depCount, targetFile, displayTargetFile)
 }
 
-// runTestInternal is the shared implementation for RunTest and RunTestWithResources.
-func runTestInternal(
+// RunTestWithResourcesByComponent executes the test flow with the provided test resources and
+// reports one result per component covered by the test.
+//
+// A test run against an SBOM covers every component in that document but is reported by the
+// test API as a single test, so the findings are split back out per component. This gives the
+// same one-result-per-project reporting as `snyk test --all-projects`, where each dep graph is
+// its own test. It falls back to a single result when the test API reports no components.
+func RunTestWithResourcesByComponent(
+	ctx context.Context,
+	targetDir string,
+	testClient testapi.TestClient,
+	resources []testapi.TestResourceCreateItem,
+	projectName string,
+	packageManager string,
+	depCount int,
+	targetFile string,
+	displayTargetFile string,
+	orgID string,
+	testConfig *testapi.TestConfiguration,
+) ([]definitions.LegacyVulnerabilityResponse, []workflow.Data, error) {
+	startParams := testapi.NewStartTestParamsFromResources(orgID, &resources, testConfig)
+	return runTestInternal(ctx, targetDir, testClient, startParams, &testTarget{
+		projectName:       projectName,
+		packageManager:    packageManager,
+		depCount:          depCount,
+		targetFile:        targetFile,
+		displayTargetFile: displayTargetFile,
+	}, true)
+}
+
+// testTarget describes what a set of findings is reported against: one project for a dep
+// graph test, or one component when an SBOM test's results are split by component.
+type testTarget struct {
+	findings          []testapi.FindingData
+	projectID         *string
+	projectName       string
+	packageManager    string
+	depCount          int
+	targetFile        string
+	displayTargetFile string
+}
+
+// runSingleTest runs a test and reports its findings as a single result.
+func runSingleTest(
 	ctx context.Context,
 	targetDir string,
 	testClient testapi.TestClient,
@@ -88,9 +130,34 @@ func runTestInternal(
 	targetFile string,
 	displayTargetFile string,
 ) (*definitions.LegacyVulnerabilityResponse, []workflow.Data, error) {
+	legacyResponses, outputData, err := runTestInternal(ctx, targetDir, testClient, startParams, &testTarget{
+		projectName:       projectName,
+		packageManager:    packageManager,
+		depCount:          depCount,
+		targetFile:        targetFile,
+		displayTargetFile: displayTargetFile,
+	}, false)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(legacyResponses) == 0 {
+		return nil, outputData, nil
+	}
+	return &legacyResponses[0], outputData, nil
+}
+
+// runTestInternal is the shared implementation for RunTest, RunTestWithResources and
+// RunTestWithResourcesByComponent.
+func runTestInternal(
+	ctx context.Context,
+	targetDir string,
+	testClient testapi.TestClient,
+	startParams testapi.StartTestParams,
+	base *testTarget,
+	splitByComponent bool,
+) ([]definitions.LegacyVulnerabilityResponse, []workflow.Data, error) {
 	cfg := cmdctx.Config(ctx)
 	logger := cmdctx.Logger(ctx)
-	errFactory := cmdctx.ErrorFactory(ctx)
 
 	finalResult, findingsData, err := executeTest(ctx, testClient, startParams)
 	if err != nil {
@@ -103,10 +170,97 @@ func runTestInternal(
 		orgSlugOrID = startParams.OrgID()
 	}
 
-	allFindingsData := findingsData
-	vulnerablePathsCount := calculateVulnerablePathsCount(allFindingsData)
+	base.findings = findingsData
 
-	consolidatedFindings, err := ConsolidateFindings(ctx, allFindingsData)
+	base.projectID, err = getTestProjectID(finalResult)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to extract project ID: %w", err)
+	}
+
+	// Use dependency count from test facts if available, otherwise fall back to the provided depCount.
+	if factDepCount := GetDependencyCountFromTestFacts(finalResult); factDepCount > 0 {
+		base.depCount = factDepCount
+	}
+
+	targets := []testTarget{*base}
+	if splitByComponent {
+		if split := SplitFindingsByComponent(finalResult, findingsData); len(split) > 0 {
+			targets = componentTargets(split, base)
+		}
+	}
+
+	var legacyResponses []definitions.LegacyVulnerabilityResponse
+	var outputData []workflow.Data
+	for i := range targets {
+		legacyResponse, targetOutput, targetErr := prepareTargetOutput(ctx, finalResult, &targets[i], targetDir, orgSlugOrID)
+		if targetErr != nil {
+			return nil, nil, targetErr
+		}
+		if legacyResponse != nil {
+			legacyResponses = append(legacyResponses, *legacyResponse)
+		}
+		outputData = append(outputData, targetOutput...)
+	}
+
+	// The test result describes the whole run, so it is emitted once no matter how many
+	// components the findings were split across. It goes last so that the findings and
+	// summary of each target stay adjacent, which is what the output workflow pairs on.
+	if testResultData := prepareTestResultData(ctx, finalResult, base, targetDir); testResultData != nil {
+		outputData = append(outputData, testResultData)
+	}
+
+	return legacyResponses, outputData, nil
+}
+
+// componentTargets turns per-component findings into reportable targets.
+//
+// The flow's own target file is kept, and the component key becomes the display target file
+// so that each result is headed by the component it covers. This mirrors `--all-projects`,
+// where every project shares the input directory and is distinguished by its target file.
+func componentTargets(split []ComponentFindings, base *testTarget) []testTarget {
+	targets := make([]testTarget, 0, len(split))
+	for _, component := range split {
+		target := *base
+		target.findings = component.Findings
+
+		if component.Key != "" {
+			target.projectName = component.Key
+			target.displayTargetFile = component.Key
+		}
+
+		if component.ProjectID != nil {
+			target.projectID = component.ProjectID
+		} else if len(split) > 1 {
+			// The test-wide project is not any single component's project, so pointing
+			// every component at it would be wrong.
+			target.projectID = nil
+		}
+
+		// The test API only reports a dependency count for the test as a whole, so it is
+		// only meaningful when that test covers a single component.
+		if len(split) > 1 {
+			target.depCount = 0
+		}
+
+		targets = append(targets, target)
+	}
+	return targets
+}
+
+// prepareTargetOutput builds the legacy JSON response and workflow data for a single target.
+func prepareTargetOutput(
+	ctx context.Context,
+	result testapi.TestResult,
+	target *testTarget,
+	targetDir string,
+	orgSlugOrID string,
+) (*definitions.LegacyVulnerabilityResponse, []workflow.Data, error) {
+	logger := cmdctx.Logger(ctx)
+	errFactory := cmdctx.ErrorFactory(ctx)
+
+	vulnerablePathsCount := calculateVulnerablePathsCount(target.findings)
+
+	consolidatedFindings, err := ConsolidateFindings(ctx, target.findings)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to consolidate findings: %w", err)
 	}
@@ -118,7 +272,7 @@ func runTestInternal(
 		logger.Warn().Err(summaryErr).Msg("Failed to create test summary for exit code handling")
 	}
 
-	remFindings, err := remediation.ShimFindingsToRemediationFindings(allFindingsData)
+	remFindings, err := remediation.ShimFindingsToRemediationFindings(target.findings)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to convert to remediation findings: %w", err)
 	}
@@ -128,29 +282,18 @@ func runTestInternal(
 		return nil, nil, fmt.Errorf("failed to compute remediation summary: %w", err)
 	}
 
-	projectID, err := getTestProjectID(finalResult)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to extract project ID: %w", err)
-	}
-
-	// Use dependency count from test facts if available, otherwise fall back to the provided depCount.
-	effectiveDepCount := depCount
-	if factDepCount := GetDependencyCountFromTestFacts(finalResult); factDepCount > 0 {
-		effectiveDepCount = factDepCount
-	}
-
 	legacyParams := &transform.SnykSchemaToLegacyParams{
-		Findings:           allFindingsData,
-		ProjectID:          projectID,
+		Findings:           target.findings,
+		ProjectID:          target.projectID,
 		RemediationSummary: remSummary,
-		TestResult:         finalResult,
+		TestResult:         result,
 		OrgSlugOrID:        orgSlugOrID,
-		ProjectName:        projectName,
-		PackageManager:     packageManager,
+		ProjectName:        target.projectName,
+		PackageManager:     target.packageManager,
 		TargetDir:          targetDir,
-		DepCount:           effectiveDepCount,
-		TargetFile:         targetFile,
-		DisplayTargetFile:  displayTargetFile,
+		DepCount:           target.depCount,
+		TargetFile:         target.targetFile,
+		DisplayTargetFile:  target.displayTargetFile,
 		ErrFactory:         errFactory,
 		Logger:             logger,
 	}
@@ -335,6 +478,21 @@ func appendTestConfig(dbg *zerolog.Event, cfg *testapi.TestConfiguration) *zerol
 	return dbg
 }
 
+// prepareTestResultData sets the test-level metadata on the result and wraps it as workflow
+// data. The metadata describes the test as a whole, so it is taken from the flow's own values
+// rather than from any one component the findings may have been split across.
+func prepareTestResultData(ctx context.Context, result testapi.TestResult, base *testTarget, targetDir string) workflow.Data {
+	ictx := cmdctx.Ictx(ctx)
+
+	result.SetMetadata("package-manager", base.packageManager)
+	result.SetMetadata("project-name", base.projectName)
+	result.SetMetadata("display-target-file", base.displayTargetFile)
+	result.SetMetadata("target-directory", targetDir)
+	result.SetMetadata("dependency-count", base.depCount)
+
+	return ufm.CreateWorkflowDataFromTestResults(ictx.GetWorkflowIdentifier(), []testapi.TestResult{result})
+}
+
 // prepareOutput prepares raw test result findings into data for the output workflow.
 // If JSON is requested (either to file or stdout), it generates legacy JSON findings.
 // If JSON-stdout is not requested, then human-readable findings are added to the output workflow.
@@ -347,25 +505,11 @@ func prepareOutput(
 	params *transform.SnykSchemaToLegacyParams,
 	vulnerablePathsCount int,
 ) (*definitions.LegacyVulnerabilityResponse, []workflow.Data, error) {
-	ictx := cmdctx.Ictx(ctx)
 	cfg := cmdctx.Config(ctx)
 
 	var outputData []workflow.Data
 	if summaryData != nil {
 		outputData = append(outputData, summaryData)
-	}
-
-	// set metadata on the test result
-	params.TestResult.SetMetadata("package-manager", params.PackageManager)
-	params.TestResult.SetMetadata("project-name", params.ProjectName)
-	params.TestResult.SetMetadata("display-target-file", params.DisplayTargetFile)
-	params.TestResult.SetMetadata("target-directory", params.TargetDir)
-	params.TestResult.SetMetadata("dependency-count", params.DepCount)
-
-	// always output the test result
-	testResultData := ufm.CreateWorkflowDataFromTestResults(ictx.GetWorkflowIdentifier(), []testapi.TestResult{params.TestResult})
-	if testResultData != nil {
-		outputData = append(outputData, testResultData)
 	}
 
 	if cfg.GetBool(outputworkflow.OutputConfigKeyNoOutput) {

--- a/internal/commands/ostest/test_execution.go
+++ b/internal/commands/ostest/test_execution.go
@@ -78,11 +78,6 @@ func RunTestWithResources(
 
 // RunTestWithResourcesByComponent executes the test flow with the provided test resources and
 // reports one result per component covered by the test.
-//
-// A test run against an SBOM covers every component in that document but is reported by the
-// test API as a single test, so the findings are split back out per component. This gives the
-// same one-result-per-project reporting as `snyk test --all-projects`, where each dep graph is
-// its own test. It falls back to a single result when the test API reports no components.
 func RunTestWithResourcesByComponent(
 	ctx context.Context,
 	targetDir string,
@@ -106,8 +101,6 @@ func RunTestWithResourcesByComponent(
 	}, true)
 }
 
-// testTarget describes what a set of findings is reported against: one project for a dep
-// graph test, or one component when an SBOM test's results are split by component.
 type testTarget struct {
 	findings          []testapi.FindingData
 	projectID         *string
@@ -118,7 +111,6 @@ type testTarget struct {
 	displayTargetFile string
 }
 
-// runSingleTest runs a test and reports its findings as a single result.
 func runSingleTest(
 	ctx context.Context,
 	targetDir string,
@@ -146,8 +138,6 @@ func runSingleTest(
 	return &legacyResponses[0], outputData, nil
 }
 
-// runTestInternal is the shared implementation for RunTest, RunTestWithResources and
-// RunTestWithResourcesByComponent.
 func runTestInternal(
 	ctx context.Context,
 	targetDir string,
@@ -177,7 +167,6 @@ func runTestInternal(
 		return nil, nil, fmt.Errorf("failed to extract project ID: %w", err)
 	}
 
-	// Use dependency count from test facts if available, otherwise fall back to the provided depCount.
 	if factDepCount := GetDependencyCountFromTestFacts(finalResult); factDepCount > 0 {
 		base.depCount = factDepCount
 	}
@@ -208,8 +197,6 @@ func runTestInternal(
 		outputData = append(outputData, targetOutput...)
 	}
 
-	// Test results go last so that the findings and summary of each target stay adjacent,
-	// which is what the output workflow pairs on.
 	if testResultData := prepareTestResultData(ctx, finalResult, base, targetDir, split, targets); testResultData != nil {
 		outputData = append(outputData, testResultData)
 	}
@@ -217,11 +204,6 @@ func runTestInternal(
 	return legacyResponses, outputData, nil
 }
 
-// componentTargets turns per-component findings into reportable targets.
-//
-// The flow's own target file is kept, and the component key becomes the display target file
-// so that each result is headed by the component it covers. This mirrors `--all-projects`,
-// where every project shares the input directory and is distinguished by its target file.
 func componentTargets(split []ComponentFindings, base *testTarget) []testTarget {
 	targets := make([]testTarget, 0, len(split))
 	for _, component := range split {
@@ -236,13 +218,9 @@ func componentTargets(split []ComponentFindings, base *testTarget) []testTarget 
 		if component.ProjectID != nil {
 			target.projectID = util.Ptr(component.ProjectID.String())
 		} else if len(split) > 1 {
-			// The test-wide project is not any single component's project, so pointing
-			// every component at it would be wrong.
 			target.projectID = nil
 		}
 
-		// The test API only reports a dependency count for the test as a whole, so it is
-		// only meaningful when that test covers a single component.
 		if len(split) > 1 {
 			target.depCount = 0
 		}
@@ -252,7 +230,6 @@ func componentTargets(split []ComponentFindings, base *testTarget) []testTarget 
 	return targets
 }
 
-// prepareTargetOutput builds the legacy JSON response and workflow data for a single target.
 func prepareTargetOutput(
 	ctx context.Context,
 	result testapi.TestResult,
@@ -483,12 +460,6 @@ func appendTestConfig(dbg *zerolog.Event, cfg *testapi.TestConfiguration) *zerol
 	return dbg
 }
 
-// prepareTestResultData sets the test-level metadata on the result and wraps the results as
-// workflow data.
-//
-// The unified findings presenter renders one section per test result, so when the findings
-// were split by component each component is presented as its own test result. Otherwise the
-// single underlying result is emitted as-is.
 func prepareTestResultData(
 	ctx context.Context,
 	result testapi.TestResult,

--- a/internal/commands/ostest/test_execution.go
+++ b/internal/commands/ostest/test_execution.go
@@ -183,8 +183,14 @@ func runTestInternal(
 	}
 
 	targets := []testTarget{*base}
+	var split []ComponentFindings
 	if splitByComponent {
-		if split := SplitFindingsByComponent(finalResult, findingsData); len(split) > 0 {
+		split = SplitFindingsByComponent(finalResult, findingsData)
+		logger.Debug().
+			Int("component_count", len(split)).
+			Strs("component_keys", componentKeys(split)).
+			Msg("Splitting test results by component")
+		if len(split) > 0 {
 			targets = componentTargets(split, base)
 		}
 	}
@@ -202,10 +208,9 @@ func runTestInternal(
 		outputData = append(outputData, targetOutput...)
 	}
 
-	// The test result describes the whole run, so it is emitted once no matter how many
-	// components the findings were split across. It goes last so that the findings and
-	// summary of each target stay adjacent, which is what the output workflow pairs on.
-	if testResultData := prepareTestResultData(ctx, finalResult, base, targetDir); testResultData != nil {
+	// Test results go last so that the findings and summary of each target stay adjacent,
+	// which is what the output workflow pairs on.
+	if testResultData := prepareTestResultData(ctx, finalResult, base, targetDir, split, targets); testResultData != nil {
 		outputData = append(outputData, testResultData)
 	}
 
@@ -229,7 +234,7 @@ func componentTargets(split []ComponentFindings, base *testTarget) []testTarget 
 		}
 
 		if component.ProjectID != nil {
-			target.projectID = component.ProjectID
+			target.projectID = util.Ptr(component.ProjectID.String())
 		} else if len(split) > 1 {
 			// The test-wide project is not any single component's project, so pointing
 			// every component at it would be wrong.
@@ -478,10 +483,20 @@ func appendTestConfig(dbg *zerolog.Event, cfg *testapi.TestConfiguration) *zerol
 	return dbg
 }
 
-// prepareTestResultData sets the test-level metadata on the result and wraps it as workflow
-// data. The metadata describes the test as a whole, so it is taken from the flow's own values
-// rather than from any one component the findings may have been split across.
-func prepareTestResultData(ctx context.Context, result testapi.TestResult, base *testTarget, targetDir string) workflow.Data {
+// prepareTestResultData sets the test-level metadata on the result and wraps the results as
+// workflow data.
+//
+// The unified findings presenter renders one section per test result, so when the findings
+// were split by component each component is presented as its own test result. Otherwise the
+// single underlying result is emitted as-is.
+func prepareTestResultData(
+	ctx context.Context,
+	result testapi.TestResult,
+	base *testTarget,
+	targetDir string,
+	split []ComponentFindings,
+	targets []testTarget,
+) workflow.Data {
 	ictx := cmdctx.Ictx(ctx)
 
 	result.SetMetadata("package-manager", base.packageManager)
@@ -490,7 +505,12 @@ func prepareTestResultData(ctx context.Context, result testapi.TestResult, base 
 	result.SetMetadata("target-directory", targetDir)
 	result.SetMetadata("dependency-count", base.depCount)
 
-	return ufm.CreateWorkflowDataFromTestResults(ictx.GetWorkflowIdentifier(), []testapi.TestResult{result})
+	results := []testapi.TestResult{result}
+	if len(split) > 0 {
+		results = componentTestResults(result, split, targets, targetDir)
+	}
+
+	return ufm.CreateWorkflowDataFromTestResults(ictx.GetWorkflowIdentifier(), results)
 }
 
 // prepareOutput prepares raw test result findings into data for the output workflow.

--- a/internal/commands/ostest/workflow.go
+++ b/internal/commands/ostest/workflow.go
@@ -133,7 +133,7 @@ func executeFlow(
 
 	switch flow {
 	case SbomFlow:
-		findings, data, err := common.RunSbomFlow(ctx, sbom, clients, orgUUID, localPolicy, reachOpts, RunTestWithResources)
+		findings, data, err := common.RunSbomFlow(ctx, sbom, clients, orgUUID, localPolicy, reachOpts, RunTestWithResourcesByComponent)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to run sbom flow: %w", err)
 		}

--- a/internal/common/dfly_depgraph_flow_test.go
+++ b/internal/common/dfly_depgraph_flow_test.go
@@ -164,18 +164,19 @@ func Test_RunDflyDepgraphFlow_HumanReadable(t *testing.T) {
 	require.True(t, ok)
 	snaps.MatchJSON(t, summary)
 
-	testResult := ufm.GetTestResultsFromWorkflowData(outputData[1])
-	require.Len(t, testResult, 1)
-
-	require.Contains(t, "application/json; schema=local-unified-finding", outputData[2].GetContentType())
-	localFindings, ok := outputData[2].GetPayload().([]byte)
+	require.Contains(t, "application/json; schema=local-unified-finding", outputData[1].GetContentType())
+	localFindings, ok := outputData[1].GetPayload().([]byte)
 	require.True(t, ok)
 	snaps.MatchJSON(t, dflyIDRgxp.ReplaceAll(localFindings, nil))
 
-	require.Contains(t, "application/json; schema=local-unified-summary", outputData[3].GetContentType())
-	localSummary, ok := outputData[3].GetPayload().([]byte)
+	require.Contains(t, "application/json; schema=local-unified-summary", outputData[2].GetContentType())
+	localSummary, ok := outputData[2].GetPayload().([]byte)
 	require.True(t, ok)
 	snaps.MatchJSON(t, localSummary)
+
+	// The test result is emitted last, after every project's findings and summary.
+	testResult := ufm.GetTestResultsFromWorkflowData(outputData[3])
+	require.Len(t, testResult, 1)
 }
 
 func Test_RunDflyDepgraphFlow_UploadingDepgraphsFail(t *testing.T) {

--- a/internal/common/dfly_depgraph_flow_test.go
+++ b/internal/common/dfly_depgraph_flow_test.go
@@ -174,7 +174,6 @@ func Test_RunDflyDepgraphFlow_HumanReadable(t *testing.T) {
 	require.True(t, ok)
 	snaps.MatchJSON(t, localSummary)
 
-	// The test result is emitted last, after every project's findings and summary.
 	testResult := ufm.GetTestResultsFromWorkflowData(outputData[3])
 	require.Len(t, testResult, 1)
 }

--- a/internal/common/sbom_flow.go
+++ b/internal/common/sbom_flow.go
@@ -25,7 +25,7 @@ func RunSbomFlow(
 	orgUUID uuid.UUID,
 	localPolicy *testapi.LocalPolicy,
 	reachabilityOpts *ReachabilityOpts,
-	runTest RunTestWithResourcesFunc,
+	runTest RunTestWithResourcesByComponentFunc,
 ) ([]definitions.LegacyVulnerabilityResponse, []workflow.Data, error) {
 	cfg := cmdctx.Config(ctx)
 	logger := cmdctx.Logger(ctx)
@@ -71,17 +71,15 @@ func RunSbomFlow(
 	testConfig := BuildTestConfig(cfg, localPolicy)
 
 	osAnalysisStart := time.Now()
-	legacyVuln, wfData, err := runTest(
+	// The SBOM is tested as a single test, but it may cover several components. The results
+	// are reported one per component, matching how `snyk test --all-projects` reports one
+	// result per project.
+	legacyVulnRes, wfData, err := runTest(
 		ctx, targetDir, clients.TestClient, resources,
 		"", "", 0, sbomPath, sbomPath, orgUUID.String(), testConfig,
 	)
 	if inst != nil {
 		inst.RecordOSAnalysisTime(time.Since(osAnalysisStart).Milliseconds())
-	}
-
-	var legacyVulnRes []definitions.LegacyVulnerabilityResponse
-	if legacyVuln != nil {
-		legacyVulnRes = []definitions.LegacyVulnerabilityResponse{*legacyVuln}
 	}
 
 	return legacyVulnRes, wfData, err

--- a/internal/common/sbom_flow.go
+++ b/internal/common/sbom_flow.go
@@ -71,9 +71,6 @@ func RunSbomFlow(
 	testConfig := BuildTestConfig(cfg, localPolicy)
 
 	osAnalysisStart := time.Now()
-	// The SBOM is tested as a single test, but it may cover several components. The results
-	// are reported one per component, matching how `snyk test --all-projects` reports one
-	// result per project.
 	legacyVulnRes, wfData, err := runTest(
 		ctx, targetDir, clients.TestClient, resources,
 		"", "", 0, sbomPath, sbomPath, orgUUID.String(), testConfig,

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -47,9 +47,8 @@ type RunTestWithResourcesFunc func(
 	testConfig *testapi.TestConfiguration,
 ) (*definitions.LegacyVulnerabilityResponse, []workflow.Data, error)
 
-// RunTestWithResourcesByComponentFunc is the function signature for executing a test
-// against the test API using uploaded resources, reporting one result per component
-// covered by the test rather than one result for the test as a whole.
+// RunTestWithResourcesByComponentFunc executes a test using uploaded resources and
+// reports one result per component.
 type RunTestWithResourcesByComponentFunc func(
 	ctx context.Context,
 	targetDir string,

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -46,3 +46,20 @@ type RunTestWithResourcesFunc func(
 	orgID string,
 	testConfig *testapi.TestConfiguration,
 ) (*definitions.LegacyVulnerabilityResponse, []workflow.Data, error)
+
+// RunTestWithResourcesByComponentFunc is the function signature for executing a test
+// against the test API using uploaded resources, reporting one result per component
+// covered by the test rather than one result for the test as a whole.
+type RunTestWithResourcesByComponentFunc func(
+	ctx context.Context,
+	targetDir string,
+	testClient testapi.TestClient,
+	resources []testapi.TestResourceCreateItem,
+	projectName string,
+	packageManager string,
+	depCount int,
+	targetFile string,
+	displayTargetFile string,
+	orgID string,
+	testConfig *testapi.TestConfiguration,
+) ([]definitions.LegacyVulnerabilityResponse, []workflow.Data, error)

--- a/internal/presenters/funcs.go
+++ b/internal/presenters/funcs.go
@@ -448,6 +448,7 @@ func getCliTemplateFuncMap(tmpl *template.Template) template.FuncMap {
 	fnMap["isIgnoredFinding"] = isIgnoredFinding
 	fnMap["hasSuppression"] = hasSuppression
 	fnMap["collectAllFindings"] = collectAllFindings
+	fnMap["collectAssetLinks"] = collectAssetLinks
 	fnMap["summaryData"] = summaryData
 	fnMap["shouldShowAggregateSummary"] = shouldShowAggregateSummary
 	return fnMap
@@ -479,6 +480,27 @@ func collectAllFindings(results []*UnifiedProjectResult) []testapi.FindingData {
 	}
 
 	return allFindings
+}
+
+// collectAssetLinks lists the distinct asset links of the given results, in the order they
+// first appear.
+//
+// An SBOM test reports one result per component but covers a single asset, so the same link
+// arrives on every component and is rendered once. Flows that test several projects
+// separately can report a different asset for each, so those are all kept.
+func collectAssetLinks(results []*UnifiedProjectResult) []string {
+	var links []string
+	seen := make(map[string]bool, len(results))
+
+	for _, result := range results {
+		if result.AssetLink == "" || seen[result.AssetLink] {
+			continue
+		}
+		seen[result.AssetLink] = true
+		links = append(links, result.AssetLink)
+	}
+
+	return links
 }
 
 // shouldShowAggregateSummary determines if an aggregate summary should be shown

--- a/internal/presenters/funcs.go
+++ b/internal/presenters/funcs.go
@@ -482,11 +482,6 @@ func collectAllFindings(results []*UnifiedProjectResult) []testapi.FindingData {
 	return allFindings
 }
 
-// firstAssetLink returns the asset link of the first result that carries one, or an empty
-// string if none do.
-//
-// A run has a single asset, and an SBOM test reports one result per component, each
-// carrying a copy of the same link, so it is rendered once rather than under every project.
 func firstAssetLink(results []*UnifiedProjectResult) string {
 	for _, result := range results {
 		if result.AssetLink != "" {

--- a/internal/presenters/funcs.go
+++ b/internal/presenters/funcs.go
@@ -448,7 +448,7 @@ func getCliTemplateFuncMap(tmpl *template.Template) template.FuncMap {
 	fnMap["isIgnoredFinding"] = isIgnoredFinding
 	fnMap["hasSuppression"] = hasSuppression
 	fnMap["collectAllFindings"] = collectAllFindings
-	fnMap["collectAssetLinks"] = collectAssetLinks
+	fnMap["firstAssetLink"] = firstAssetLink
 	fnMap["summaryData"] = summaryData
 	fnMap["shouldShowAggregateSummary"] = shouldShowAggregateSummary
 	return fnMap
@@ -482,25 +482,19 @@ func collectAllFindings(results []*UnifiedProjectResult) []testapi.FindingData {
 	return allFindings
 }
 
-// collectAssetLinks lists the distinct asset links of the given results, in the order they
-// first appear.
+// firstAssetLink returns the asset link of the first result that carries one, or an empty
+// string if none do.
 //
-// An SBOM test reports one result per component but covers a single asset, so the same link
-// arrives on every component and is rendered once. Flows that test several projects
-// separately can report a different asset for each, so those are all kept.
-func collectAssetLinks(results []*UnifiedProjectResult) []string {
-	var links []string
-	seen := make(map[string]bool, len(results))
-
+// A run has a single asset, and an SBOM test reports one result per component, each
+// carrying a copy of the same link, so it is rendered once rather than under every project.
+func firstAssetLink(results []*UnifiedProjectResult) string {
 	for _, result := range results {
-		if result.AssetLink == "" || seen[result.AssetLink] {
-			continue
+		if result.AssetLink != "" {
+			return result.AssetLink
 		}
-		seen[result.AssetLink] = true
-		links = append(links, result.AssetLink)
 	}
 
-	return links
+	return ""
 }
 
 // shouldShowAggregateSummary determines if an aggregate summary should be shown

--- a/internal/presenters/presenter_unified_finding_test.go
+++ b/internal/presenters/presenter_unified_finding_test.go
@@ -1461,7 +1461,7 @@ func TestUnifiedFindingPresenter_AssetLink(t *testing.T) {
 			"the asset link belongs to the run as a whole, so it comes after the overall test summary")
 	})
 
-	t.Run("keeps distinct asset links when projects are tested separately", func(t *testing.T) {
+	t.Run("renders a single link when results carry differing asset values", func(t *testing.T) {
 		config := configuration.New()
 		buffer := &bytes.Buffer{}
 		lipgloss.SetColorProfile(termenv.Ascii)
@@ -1493,9 +1493,8 @@ func TestUnifiedFindingPresenter_AssetLink(t *testing.T) {
 		err := presenter.RenderTemplate(presenters.DefaultTemplateFiles, presenters.DefaultMimeType)
 		require.NoError(t, err)
 
-		output := buffer.String()
-		assert.Contains(t, output, "View your asset(s) at: app.snyk.io/inventory/asset-a")
-		assert.Contains(t, output, "View your asset(s) at: app.snyk.io/inventory/asset-b")
+		// A run has a single asset, so there is never more than one link to show.
+		assert.Equal(t, 1, strings.Count(buffer.String(), "View your asset(s) at:"))
 	})
 
 	t.Run("omits asset link line when empty (default sbom test)", func(t *testing.T) {

--- a/internal/presenters/presenter_unified_finding_test.go
+++ b/internal/presenters/presenter_unified_finding_test.go
@@ -1419,6 +1419,85 @@ func TestUnifiedFindingPresenter_AssetLink(t *testing.T) {
 			"View your asset(s) at: app.snyk.io/inventory/b6b8bbf8-5cbf-40a2-8991-784fe2a6c8a1")
 	})
 
+	t.Run("renders the shared asset link once, below the overall test summary", func(t *testing.T) {
+		config := configuration.New()
+		buffer := &bytes.Buffer{}
+		lipgloss.SetColorProfile(termenv.Ascii)
+
+		assetLink := "app.snyk.io/inventory/b6b8bbf8-5cbf-40a2-8991-784fe2a6c8a1"
+		newResult := func(target string) *presenters.UnifiedProjectResult {
+			return &presenters.UnifiedProjectResult{
+				Findings:          []testapi.FindingData{},
+				DisplayTargetFile: target,
+				TargetDirectory:   "/home/me",
+				Summary: &json_schemas.TestSummary{
+					Type:             "open-source",
+					Path:             "/home/me",
+					SeverityOrderAsc: []string{"low", "medium", "high", "critical"},
+					Results:          []json_schemas.TestSummaryResult{},
+				},
+				AssetLink: assetLink,
+			}
+		}
+
+		// An SBOM test reports one result per component, all covering the same asset.
+		presenter := presenters.NewUnifiedFindingsRenderer(
+			[]*presenters.UnifiedProjectResult{
+				newResult("pkg:npm/app-a@1.0.0"),
+				newResult("pkg:npm/app-b@2.0.0"),
+				newResult("pkg:npm/app-c@3.0.0"),
+			},
+			config,
+			buffer,
+		)
+
+		err := presenter.RenderTemplate(presenters.DefaultTemplateFiles, presenters.DefaultMimeType)
+		require.NoError(t, err)
+
+		output := buffer.String()
+		assert.Equal(t, 1, strings.Count(output, "View your asset(s) at:"),
+			"the asset covers the whole run, so it is not repeated under every component")
+		assert.Greater(t, strings.Index(output, "View your asset(s) at:"), strings.Index(output, "Overall Test Summary"),
+			"the asset link belongs to the run as a whole, so it comes after the overall test summary")
+	})
+
+	t.Run("keeps distinct asset links when projects are tested separately", func(t *testing.T) {
+		config := configuration.New()
+		buffer := &bytes.Buffer{}
+		lipgloss.SetColorProfile(termenv.Ascii)
+
+		newResult := func(target, assetLink string) *presenters.UnifiedProjectResult {
+			return &presenters.UnifiedProjectResult{
+				Findings:          []testapi.FindingData{},
+				DisplayTargetFile: target,
+				TargetDirectory:   "/home/me",
+				Summary: &json_schemas.TestSummary{
+					Type:             "open-source",
+					Path:             "/home/me",
+					SeverityOrderAsc: []string{"low", "medium", "high", "critical"},
+					Results:          []json_schemas.TestSummaryResult{},
+				},
+				AssetLink: assetLink,
+			}
+		}
+
+		presenter := presenters.NewUnifiedFindingsRenderer(
+			[]*presenters.UnifiedProjectResult{
+				newResult("a/package.json", "app.snyk.io/inventory/asset-a"),
+				newResult("b/package.json", "app.snyk.io/inventory/asset-b"),
+			},
+			config,
+			buffer,
+		)
+
+		err := presenter.RenderTemplate(presenters.DefaultTemplateFiles, presenters.DefaultMimeType)
+		require.NoError(t, err)
+
+		output := buffer.String()
+		assert.Contains(t, output, "View your asset(s) at: app.snyk.io/inventory/asset-a")
+		assert.Contains(t, output, "View your asset(s) at: app.snyk.io/inventory/asset-b")
+	})
+
 	t.Run("omits asset link line when empty (default sbom test)", func(t *testing.T) {
 		config := configuration.New()
 		buffer := &bytes.Buffer{}

--- a/internal/presenters/presenter_unified_finding_test.go
+++ b/internal/presenters/presenter_unified_finding_test.go
@@ -1440,7 +1440,6 @@ func TestUnifiedFindingPresenter_AssetLink(t *testing.T) {
 			}
 		}
 
-		// An SBOM test reports one result per component, all covering the same asset.
 		presenter := presenters.NewUnifiedFindingsRenderer(
 			[]*presenters.UnifiedProjectResult{
 				newResult("pkg:npm/app-a@1.0.0"),
@@ -1459,42 +1458,6 @@ func TestUnifiedFindingPresenter_AssetLink(t *testing.T) {
 			"the asset covers the whole run, so it is not repeated under every component")
 		assert.Greater(t, strings.Index(output, "View your asset(s) at:"), strings.Index(output, "Overall Test Summary"),
 			"the asset link belongs to the run as a whole, so it comes after the overall test summary")
-	})
-
-	t.Run("renders a single link when results carry differing asset values", func(t *testing.T) {
-		config := configuration.New()
-		buffer := &bytes.Buffer{}
-		lipgloss.SetColorProfile(termenv.Ascii)
-
-		newResult := func(target, assetLink string) *presenters.UnifiedProjectResult {
-			return &presenters.UnifiedProjectResult{
-				Findings:          []testapi.FindingData{},
-				DisplayTargetFile: target,
-				TargetDirectory:   "/home/me",
-				Summary: &json_schemas.TestSummary{
-					Type:             "open-source",
-					Path:             "/home/me",
-					SeverityOrderAsc: []string{"low", "medium", "high", "critical"},
-					Results:          []json_schemas.TestSummaryResult{},
-				},
-				AssetLink: assetLink,
-			}
-		}
-
-		presenter := presenters.NewUnifiedFindingsRenderer(
-			[]*presenters.UnifiedProjectResult{
-				newResult("a/package.json", "app.snyk.io/inventory/asset-a"),
-				newResult("b/package.json", "app.snyk.io/inventory/asset-b"),
-			},
-			config,
-			buffer,
-		)
-
-		err := presenter.RenderTemplate(presenters.DefaultTemplateFiles, presenters.DefaultMimeType)
-		require.NoError(t, err)
-
-		// A run has a single asset, so there is never more than one link to show.
-		assert.Equal(t, 1, strings.Count(buffer.String(), "View your asset(s) at:"))
 	})
 
 	t.Run("omits asset link line when empty (default sbom test)", func(t *testing.T) {

--- a/internal/presenters/templates/unified_finding.tmpl
+++ b/internal/presenters/templates/unified_finding.tmpl
@@ -255,16 +255,23 @@
         {{- "\n" }}
     {{- end }}
 
-    {{- if $result.AssetLink }}
-        {{- printf "\nView your asset(s) at: %s\n" $result.AssetLink }}
-    {{- end }}
-
 {{- end }}
 
 {{- if shouldShowAggregateSummary .Results }}
 {{- divider }}
 
 {{- box (renderToString "aggregateSummary" .Results) }}
+{{- end }}
+
+{{- /* The asset link describes the run as a whole, so it is rendered once at the end,
+       below the overall test summary, rather than under an individual project. */ -}}
+{{- $assetLinks := collectAssetLinks .Results }}
+{{- if $assetLinks }}
+    {{- /* Separate the links from the overall test summary box above them. */ -}}
+    {{- if shouldShowAggregateSummary .Results }}{{- "\n" }}{{- end }}
+    {{- range $link := $assetLinks }}
+        {{- printf "\nView your asset(s) at: %s\n" $link }}
+    {{- end }}
 {{- end }}
 
 {{- end }} {{/* end main */}}

--- a/internal/presenters/templates/unified_finding.tmpl
+++ b/internal/presenters/templates/unified_finding.tmpl
@@ -263,15 +263,12 @@
 {{- box (renderToString "aggregateSummary" .Results) }}
 {{- end }}
 
-{{- /* The asset link describes the run as a whole, so it is rendered once at the end,
-       below the overall test summary, rather than under an individual project. */ -}}
-{{- $assetLinks := collectAssetLinks .Results }}
-{{- if $assetLinks }}
-    {{- /* Separate the links from the overall test summary box above them. */ -}}
-    {{- if shouldShowAggregateSummary .Results }}{{- "\n" }}{{- end }}
-    {{- range $link := $assetLinks }}
-        {{- printf "\nView your asset(s) at: %s\n" $link }}
-    {{- end }}
+{{- /* A run has a single asset, so the link is rendered once at the end, below the overall
+       test summary, rather than under an individual project. */ -}}
+{{- with firstAssetLink .Results }}
+    {{- /* Separate the link from the overall test summary box above it. */ -}}
+    {{- if shouldShowAggregateSummary $.Results }}{{- "\n" }}{{- end }}
+    {{- printf "\nView your asset(s) at: %s\n" . }}
 {{- end }}
 
 {{- end }} {{/* end main */}}

--- a/internal/presenters/templates/unified_finding.tmpl
+++ b/internal/presenters/templates/unified_finding.tmpl
@@ -263,10 +263,7 @@
 {{- box (renderToString "aggregateSummary" .Results) }}
 {{- end }}
 
-{{- /* A run has a single asset, so the link is rendered once at the end, below the overall
-       test summary, rather than under an individual project. */ -}}
 {{- with firstAssetLink .Results }}
-    {{- /* Separate the link from the overall test summary box above it. */ -}}
     {{- if shouldShowAggregateSummary $.Results }}{{- "\n" }}{{- end }}
     {{- printf "\nView your asset(s) at: %s\n" . }}
 {{- end }}


### PR DESCRIPTION
`snyk test` against an SBOM currently reports a single result for the whole document, no matter how many components it covers. This splits the findings out by component key and reports one result per component, matching how `snyk test --all-projects` reports one result per project.

The test API runs an SBOM as a single test, so the split happens client-side on the component key carried by each finding. The components listed on the test result are the canonical, ordered list, so a component with no findings still gets its own (clean) result. The component key becomes the project name and display target file so each result is headed by the component it covers — the same way `--all-projects` distinguishes projects that share an input directory by their target file.

Values that only describe the test as a whole are dropped rather than repeated per component: the test-wide project ID isn't any single component's project, and the test API only reports a dependency count for the run. Both are kept when the test covers exactly one component. The test result itself is still emitted once, after all per-component findings and summaries, since the output workflow pairs findings with the summary that follows them.

Dep graph flows are untouched — `runSingleTest` keeps the previous single-result path, and the SBOM flow falls back to it when the test API reports no component information.