### PR TITLE
feat: register registry-based sbom monitor group opt-in flag [OSF-466]

### DIFF
--- a/internal/commands/ostest/workflow.go
+++ b/internal/commands/ostest/workflow.go
@@ -76,6 +76,8 @@ func RegisterWorkflows(e workflow.Engine) error {
 	maps.Copy(featureFlags, orchestrator.GetAllFlags())
 	config_utils.AddFeatureFlagsToConfig(e, featureFlags)
 
+	config_utils.AddFeatureFlagToConfig(e, constants.FeatureFlagEnableSbomMonitor, "enableSbomMonitor")
+
 	return nil
 }
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -39,6 +39,9 @@ const FeatureFlagDlfyCLIRollout = "internal_snyk_cli_rollout_dfly_os_cli"
 // FeatureFlagDflySbomMonitor is used to rollout the SBOM monitor flow to the dragonfly stack.
 const FeatureFlagDflySbomMonitor = "internal_snyk_cli_rollout_dfly_sbom_monitor"
 
+// FeatureFlagEnableSbomMonitor is used to opt in to the registry-based SBOM monitor flow.
+const FeatureFlagEnableSbomMonitor = "internal_snyk_cli_enable_sbom_monitor"
+
 // UploadingSourceCodeMessage is the message that's being rendered in the UI spinner while
 // the source code is being uploaded.
 const UploadingSourceCodeMessage = "Uploading source code..."


### PR DESCRIPTION
Registers the new registry-based `enableSbomMonitor` flag alongside the existing `FeatureFlagDflySbomMonitor` registration, mirroring how that flag is already declared here.

Companion to snyk/cli-extension-sbom#202, where `sbom test --report`/`--monitor` is now permitted when either the org-level feature-flags-service flag or this registry-based (group-level) flag is enabled — needed because the feature-flags service only evaluates at the org level, blocking group-wide opt-in (OSF-466).