### PR TITLE
build: bump Go toolchain to 1.26.5 [OSF-303]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/cli-extension-os-flows
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/charmbracelet/lipgloss v1.1.0


### PR DESCRIPTION
Bumps the Go toolchain from 1.26.4 to 1.26.5 to fix the stdlib Symlink Attack vulnerability (SNYK-GOLANG-STDOS-17905377) that was blocking the Snyk Enhanced Gate.

The vulnerability was published 2026-07-09 and exceeded the 30-day remediation SLA, which is why the gate started failing now rather than at merge time of the last Go bump (#01636af). This follows the same pattern as that earlier fix. `go.sum` is unchanged; `go build` and `go test ./...` both pass against the new toolchain.