### PR TITLE
fix: preserve context deadline errors through --all-projects aggregation [OSF-452]

### DIFF
--- a/internal/common/depgraph.go
+++ b/internal/common/depgraph.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
@@ -189,28 +190,30 @@ func getDepgraphsFromOrchestrator(ictx workflow.InvocationContext, inputDir stri
 
 	allProjects := config.GetBool(flags.FlagAllProjects)
 
+	return aggregateResults(ictx, results, inputDir, target, allProjects)
+}
+
+func aggregateResults(
+	ictx workflow.InvocationContext,
+	results <-chan ecosystems.SCAResult,
+	inputDir string,
+	target []byte,
+	allProjects bool,
+) ([]RawDepGraphWithMeta, error) {
 	rawDepGraphs := make([]RawDepGraphWithMeta, 0)
 	var failedErrors []error
+	var deadlineErr error
 	for result := range results {
+		if deadlineErr == nil && isTimeoutError(result.Error) {
+			deadlineErr = result.Error
+		}
+
 		if result.Error != nil && allProjects {
 			// With --all-projects, a single ecosystem failing to resolve
 			// (e.g. missing tooling for Python) should not abort the entire
 			// scan. Accumulate failures and only error if all projects fail,
 			// matching the legacy TS CLI behavior.
-			//
-			// Format the message to match legacy output:
-			//   <file>:
-			//     <error detail>
-			targetFile := ""
-			if result.ResolverMetadata != nil && result.ResolverMetadata.NormalisedTargetFile != "" {
-				targetFile = filepath.Join(inputDir, result.ResolverMetadata.NormalisedTargetFile)
-			}
-			errMsg := extractErrorDetail(result.Error)
-			if targetFile != "" {
-				failedErrors = append(failedErrors, fmt.Errorf("%s:\n  %s", targetFile, errMsg))
-			} else {
-				failedErrors = append(failedErrors, fmt.Errorf("%s", errMsg))
-			}
+			failedErrors = append(failedErrors, formatFailedProjectError(inputDir, &result))
 			continue
 		}
 
@@ -219,6 +222,10 @@ func getDepgraphsFromOrchestrator(ictx workflow.InvocationContext, inputDir stri
 			return nil, err
 		}
 		rawDepGraphs = append(rawDepGraphs, *dg)
+	}
+
+	if deadlineErr != nil {
+		return nil, fmt.Errorf("failed to get dependency graph: %w", deadlineErr)
 	}
 
 	total := len(rawDepGraphs) + len(failedErrors)
@@ -249,6 +256,22 @@ func getDepgraphsFromOrchestrator(ictx workflow.InvocationContext, inputDir stri
 		return nil, fmt.Errorf("no testable projects found")
 	}
 	return rawDepGraphs, nil
+}
+
+func isTimeoutError(err error) bool {
+	return err != nil && (stderrors.Is(err, context.DeadlineExceeded) || stderrors.Is(err, context.Canceled))
+}
+
+func formatFailedProjectError(inputDir string, result *ecosystems.SCAResult) error {
+	targetFile := ""
+	if result.ResolverMetadata != nil && result.ResolverMetadata.NormalisedTargetFile != "" {
+		targetFile = filepath.Join(inputDir, result.ResolverMetadata.NormalisedTargetFile)
+	}
+	errMsg := extractErrorDetail(result.Error)
+	if targetFile == "" {
+		return fmt.Errorf("%s", errMsg)
+	}
+	return fmt.Errorf("%s:\n  %s", targetFile, errMsg)
 }
 
 func resolveTarget(inputDir, remoteRepoURL string, logger *zerolog.Logger) []byte {

--- a/internal/common/depgraph_internal_test.go
+++ b/internal/common/depgraph_internal_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -90,4 +91,42 @@ func TestMapToRawDepGraphWithMeta_ResultError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to resolve depgraph for pom.xml")
 	assert.ErrorContains(t, err, "resolution failed")
+}
+
+func TestAggregateResults_TimeoutDuringResolutionSurfacesDeadlineExceeded(t *testing.T) {
+	results := make(chan ecosystems.SCAResult, 1)
+	results <- ecosystems.SCAResult{Error: context.DeadlineExceeded}
+	close(results)
+
+	_, err := aggregateResults(nil, results, "/test/dir", nil, true)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Contains(t, err.Error(), "failed to get dependency graph")
+}
+
+func TestAggregateResults_TimeoutTakesPrecedenceOverPartialSuccess(t *testing.T) {
+	results := make(chan ecosystems.SCAResult, 2)
+	results <- ecosystems.SCAResult{
+		ResolverMetadata: &ecosystems.ResolverMetadata{NormalisedTargetFile: "package.json"},
+	}
+	results <- ecosystems.SCAResult{Error: context.DeadlineExceeded}
+	close(results)
+
+	_, err := aggregateResults(nil, results, "/test/dir", nil, true)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestAggregateResults_NonTimeoutFailureKeepsGenericAllProjectsFailedMessage(t *testing.T) {
+	results := make(chan ecosystems.SCAResult, 1)
+	results <- ecosystems.SCAResult{Error: errors.New("boom")}
+	close(results)
+
+	_, err := aggregateResults(nil, results, "/test/dir", nil, true)
+
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, context.DeadlineExceeded))
+	assert.Contains(t, err.Error(), "failed to get dependencies for all 1 potential projects")
 }


### PR DESCRIPTION
getDepgraphsFromOrchestrator's --all-projects partial-failure handling reformatted every accumulated failure into a plain aggregate error string, which severed the error chain and dropped any context.DeadlineExceeded/Canceled signal before it reached the CLI's top-level error classifier.

This is why `SNYK_TIMEOUT_SECS=1 snyk test --all-projects` was reporting a generic failure instead of a proper command-timeout error. Extracted the aggregation loop into a testable aggregateResults function, and a result whose error wraps context.DeadlineExceeded/Canceled now takes priority and is returned with %w-wrapping preserved, regardless of allProjects or partial success. Depends on the companion fix in cli-extension-dep-graph (snyk/cli-extension-dep-graph#236), which is what actually gets the failing plugin's error onto the results channel in the first place.