### PR TITLE
Return NewCommandTimeoutError on depgraph aggregation timeout [OSF-452]

### DIFF
--- a/internal/common/depgraph.go
+++ b/internal/common/depgraph.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	snyk_cli_errors "github.com/snyk/error-catalog-golang-public/cli"
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 
 	"github.com/rs/zerolog"
@@ -225,7 +226,7 @@ func aggregateResults(
 	}
 
 	if deadlineErr != nil {
-		return nil, fmt.Errorf("failed to get dependency graph: %w", deadlineErr)
+		return nil, snyk_cli_errors.NewCommandTimeoutError("", snyk_errors.WithCause(deadlineErr))
 	}
 
 	total := len(rawDepGraphs) + len(failedErrors)
@@ -259,7 +260,7 @@ func aggregateResults(
 }
 
 func isTimeoutError(err error) bool {
-	return err != nil && (stderrors.Is(err, context.DeadlineExceeded) || stderrors.Is(err, context.Canceled))
+	return stderrors.Is(err, context.DeadlineExceeded)
 }
 
 func formatFailedProjectError(inputDir string, result *ecosystems.SCAResult) error {

--- a/internal/common/depgraph_internal_test.go
+++ b/internal/common/depgraph_internal_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/identity"
 	"github.com/snyk/dep-graph/go/pkg/depgraph"
+	snyk_cli_errors "github.com/snyk/error-catalog-golang-public/cli"
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -102,7 +104,10 @@ func TestAggregateResults_TimeoutDuringResolutionSurfacesDeadlineExceeded(t *tes
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.Contains(t, err.Error(), "failed to get dependency graph")
+
+	var snykErr snyk_errors.Error
+	require.ErrorAs(t, err, &snykErr)
+	assert.Equal(t, snyk_cli_errors.NewCommandTimeoutError("").ErrorCode, snykErr.ErrorCode)
 }
 
 func TestAggregateResults_TimeoutTakesPrecedenceOverPartialSuccess(t *testing.T) {
@@ -117,6 +122,10 @@ func TestAggregateResults_TimeoutTakesPrecedenceOverPartialSuccess(t *testing.T)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
+
+	var snykErr snyk_errors.Error
+	require.ErrorAs(t, err, &snykErr)
+	assert.Equal(t, snyk_cli_errors.NewCommandTimeoutError("").ErrorCode, snykErr.ErrorCode)
 }
 
 func TestAggregateResults_NonTimeoutFailureKeepsGenericAllProjectsFailedMessage(t *testing.T) {


### PR DESCRIPTION
When resolving dep graphs via the orchestrator with `--all-projects`, a timeout/deadline error during aggregation now returns `cli.NewCommandTimeoutError("", snyk_errors.WithCause(err))` instead of a generic wrapped error, so timeouts surface through the error-catalog with the standard command-timeout guidance.

Follows on from #273 (OSF-452), which first made sure a timeout wasn't masked by partial-success handling in `--all-projects` aggregation; this changes what error is actually returned in that case.