### PR TITLE
fix: preserve error catalog code in per-project failure summary [OSF-484]

### DIFF
--- a/internal/common/depgraph.go
+++ b/internal/common/depgraph.go
@@ -268,7 +268,7 @@ func formatFailedProjectError(inputDir string, result *ecosystems.SCAResult) err
 	if result.ResolverMetadata != nil && result.ResolverMetadata.NormalisedTargetFile != "" {
 		targetFile = filepath.Join(inputDir, result.ResolverMetadata.NormalisedTargetFile)
 	}
-	errMsg := extractErrorDetail(result.Error)
+	errMsg := formatProjectErrorMessage(result.Error)
 	if targetFile == "" {
 		return fmt.Errorf("%s", errMsg)
 	}
@@ -287,13 +287,22 @@ func resolveTarget(inputDir, remoteRepoURL string, logger *zerolog.Logger) []byt
 	return target
 }
 
-// extractErrorDetail returns the most user-readable message from an error.
-// For snyk_errors.Error the Detail field contains the full explanation;
-// Error() only returns the Title (e.g. "Unspecified Error").
-func extractErrorDetail(err error) string {
+func formatProjectErrorMessage(err error) string {
 	var snykErr snyk_errors.Error
-	if stderrors.As(err, &snykErr) && snykErr.Detail != "" {
-		return snykErr.Detail
+	if stderrors.As(err, &snykErr) {
+		detail := snykErr.Detail
+		if detail == "" {
+			detail = snykErr.Title
+		}
+		if snykErr.ErrorCode != "" && detail != "" {
+			return fmt.Sprintf("%s: %s", snykErr.ErrorCode, detail)
+		}
+		if snykErr.ErrorCode != "" {
+			return snykErr.ErrorCode
+		}
+		if detail != "" {
+			return detail
+		}
 	}
 	return err.Error()
 }

--- a/internal/common/depgraph_internal_test.go
+++ b/internal/common/depgraph_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/snyk/cli-extension-dep-graph/v2/pkg/ecosystems"
@@ -138,4 +139,48 @@ func TestAggregateResults_NonTimeoutFailureKeepsGenericAllProjectsFailedMessage(
 	require.Error(t, err)
 	assert.False(t, errors.Is(err, context.DeadlineExceeded))
 	assert.Contains(t, err.Error(), "failed to get dependencies for all 1 potential projects")
+}
+
+func TestAggregateResults_AllProjectsFailedPreservesErrorCatalogCode(t *testing.T) {
+	inputDir := t.TempDir()
+
+	results := make(chan ecosystems.SCAResult, 2)
+	results <- ecosystems.SCAResult{
+		Error: snyk_errors.Error{
+			ID:        "id-1",
+			Title:     "Pip install failed",
+			ErrorCode: "SNYK-OS-PIP-0001",
+			Detail:    "pip could not resolve the requirements",
+		},
+		ResolverMetadata: &ecosystems.ResolverMetadata{
+			NormalisedTargetFile: filepath.Join("project1", "requirements.txt"),
+		},
+	}
+	results <- ecosystems.SCAResult{
+		Error: snyk_errors.Error{
+			ID:        "id-2",
+			Title:     "Unsupported manifest",
+			ErrorCode: "SNYK-CLI-0005",
+			Detail:    "manifest could not be parsed",
+		},
+		ResolverMetadata: &ecosystems.ResolverMetadata{
+			NormalisedTargetFile: filepath.Join("project2", "package.json"),
+		},
+	}
+	close(results)
+
+	_, err := aggregateResults(nil, results, inputDir, nil, true)
+
+	require.Error(t, err)
+	msg := err.Error()
+
+	assert.Contains(t, msg, "failed to get dependencies for all 2 potential projects")
+
+	assert.Contains(t, msg, filepath.Join(inputDir, "project1", "requirements.txt"))
+	assert.Contains(t, msg, "SNYK-OS-PIP-0001", "per-project reason must include the catalog code")
+	assert.Contains(t, msg, "pip could not resolve the requirements", "per-project reason must include the detail")
+
+	assert.Contains(t, msg, filepath.Join(inputDir, "project2", "package.json"))
+	assert.Contains(t, msg, "SNYK-CLI-0005", "per-project reason must include the catalog code")
+	assert.Contains(t, msg, "manifest could not be parsed", "per-project reason must include the detail")
 }


### PR DESCRIPTION
[OSF-484](https://snyksec.atlassian.net/browse/OSF-484)

## Summary
When the unified test API FF (`FFUseUnifiedTestAPIForOSCliTest`) is on, `aggregateResults` formatted per-project failure summaries via `extractErrorDetail`, which returned only `snykErr.Detail` and dropped the `ErrorCode`. This collapsed catalog-coded failures (e.g. `SNYK-OS-PIP-0001`, `SNYK-CLI-0005`) into plain text under the outer `SNYK-CLI-0000`, so downstream tooling that keys off the code (dashboards, integrations, classifiers) bucketed unrelated failures together.

Replace `extractErrorDetail` with `formatProjectErrorMessage`, which emits `"<ErrorCode>: <Detail>"` for `snyk_errors.Error` and falls back sensibly when either field is missing.

## Test plan
- [x] Added `TestAggregateResults_AllProjectsFailedPreservesErrorCatalogCode` (fails on the old code, passes on the new).
- [x] Verified as a real regression test: temporarily swapped the fix out and both new assertions failed with the exact "does not contain SNYK-OS-PIP-0001" / "SNYK-CLI-0005" messages, then restored the fix and confirmed all tests pass.
- [x] Full `internal/common/...` test suite green.
- [x] `go build ./...` and `go vet ./...` clean.
- [ ] Manual reproducer: `mkdir /tmp/broken && cd /tmp/broken && echo '{ invalid json }' > project1/package.json && echo '{"name":}' > project2/package.json && snyk test --all-projects` with the FF on — the per-project reasons in the failure summary should now include their catalog codes.

Made with [Cursor](https://cursor.com)

[OSF-484]: https://snyksec.atlassian.net/browse/OSF-484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ